### PR TITLE
Use extraPrometheusExportersPorts to propagate monitoring port

### DIFF
--- a/globals-defaults.nix
+++ b/globals-defaults.nix
@@ -1,4 +1,10 @@
-{
+rec {
   cardanoNodePort = 3001;
   cardanoNodeLegacyPort = 3000;
+  cardanoNodePrometheusExporterPort = 12798;
+  byronProxyPrometheusExporterPort = 12799;
+  extraPrometheusExportersPorts = [
+    cardanoNodePrometheusExporterPort
+    byronProxyPrometheusExporterPort
+  ];
 } // (import ./static/globals.nix)

--- a/modules/nginx-monitoring-proxy.nix
+++ b/modules/nginx-monitoring-proxy.nix
@@ -2,14 +2,15 @@
 with import ../nix {};
 
 {
-  networking.firewall.allowedTCPPorts = [ 12798 ];
+  publicExporterPort = globals.cardanoNodePrometheusExporterPort;
+  networking.firewall.allowedTCPPorts = [ publicExporterPort ];
 
   services.nginx = {
     enable = true;
     virtualHosts."localexporter.${globals.domain}" = {
       enableACME = false;
       forceSSL = false;
-      listen = [ { addr = "0.0.0.0"; port = 12798; } ];
+      listen = [ { addr = "0.0.0.0"; port = publicExporterPort; } ];
       locations."/".proxyPass = "http://127.0.0.1:12797/";
     };
   };


### PR DESCRIPTION
 to ops-lib monitoring security group.