### PR TITLE
Benchmarking cluster

### DIFF
--- a/NOTES
+++ b/NOTES
@@ -1,0 +1,42 @@
+
+## run benchmark
+
+./restart_cluster.sh
+
+
+  - check that the cluster produces (empty) blocks:
+
+nixops ssh explorer "psql cexplorer -U cexplorer"
+
+SELECT COUNT(*) FROM block;
+
+
+  - then on explorer:
+
+nixops ssh explorer
+
+  - make sure that genesis is right and the path to the deployed binaries and configs
+./run-tx-gen.sh
+
+
+## evalute benchmark run
+
+nixops ssh explorer "./analyse-blocks.sh"
+
+
+## redeploy cluster
+
+nix-shell
+
+nixops deploy
+
+
+## tail of a log
+
+nixops ssh a "tail /var/lib/cardano-node/logs/node.json"
+
+
+## recreate genesis
+
+make-dev-genesis --n-delegate-addresses 3
+

--- a/explorer-db.sh
+++ b/explorer-db.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+nixops ssh explorer -- sh -c "'PGPASSFILE=/var/lib/cexplorer/pgpass psql cexplorer cexplorer'"

--- a/make-dev-genesis-valid
+++ b/make-dev-genesis-valid
@@ -1,0 +1,68 @@
+#!/nix/store/506nnycf7nk22x7n07mjjjl2g8nifpda-bash-4.4-p23/bin/bash
+#!/usr/bin/env bash
+
+test "$1" == "--help" && {
+        cat <<EOF
+Usage:  $(basename $0) [GENESIS-SUBCMD-ARG..]
+EOF
+      echo "" >&2; exit 1; }
+
+umask 077
+
+SCRIPTDIR=/nix/store/8hyd75xws6w2vcv031n7py5iic79qkvi-source/scripts
+CONFIGDIR="$(realpath ${SCRIPTDIR}/../configuration)"
+
+DATE=date
+OS=$(uname -s)
+if [ "$OS" = "Darwin" ]; then
+  DATE=gdate
+fi
+start_future_offset="1 minute"
+start_time="$(${DATE} -d "now + ${start_future_offset}" +%s)"
+protocol_params="${SCRIPTDIR}/protocol-params.json"
+
+parameter_k=2160
+protocol_magic=459045235
+n_poors=128
+n_delegates=7
+total_balance=8000000000000000
+delegate_share=900000000000000
+avvm_entries=128
+avvm_entry_balance=10000000000000
+not_so_secret=2718281828
+
+tmpdir="`mktemp`.d"
+args=(
+      --genesis-output-dir           "${tmpdir}"
+      --start-time                   "${start_time}"
+      --protocol-parameters-file     "${protocol_params}"
+      --k                            ${parameter_k}
+      --protocol-magic               ${protocol_magic}
+      --n-poor-addresses             ${n_poors}
+      
+      --total-balance                ${total_balance}
+      --delegate-share               ${delegate_share}
+      --avvm-entry-count             ${avvm_entries}
+      --avvm-entry-balance           ${avvm_entry_balance}
+      --secret-seed                  ${not_so_secret}
+)
+
+set -xe
+RUNNER=${RUNNER:-cabal new-run -v0 --}
+
+ cardano-cli genesis --real-pbft "${args[@]}" "$@"
+
+# move new genesis to configuration
+GENHASH=` cardano-cli "${common[@]}" print-genesis-hash --genesis-json "${tmpdir}/genesis.json" | tail -1`
+TARGETDIR="/home/dev/remote-dev-cluster-3/keys"
+mkdir -vp "${TARGETDIR}"
+cp -iav ${tmpdir}/genesis.json ${TARGETDIR}/
+cp -iav ${tmpdir}/delegate-keys.*.key ${TARGETDIR}/
+cp -iav ${tmpdir}/delegation-cert.*.json ${TARGETDIR}/
+
+set -
+
+echo $GENHASH > ${TARGETDIR}/GENHASH
+echo "genesis created with hash = ${GENHASH}"
+echo "  in directory ${TARGETDIR}"
+

--- a/restart_cluster.sh
+++ b/restart_cluster.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -xe
+
+# Restart the cluster
+
+## Stop all cardano-nodes (on core machines and on explorer machine as well)
+nixops ssh-for-each systemctl stop cardano-node
+
+## Clean up databases for all core nodes (and for node on explorer machine as well)
+nixops ssh-for-each -- rm -rf /var/lib/cardano-node/db-shelley-dev-0 /var/lib/cardano-node/db-shelley-dev-1 /var/lib/cardano-node/db-shelley-dev-2
+
+## Stop cardano-explorer-node and postgres on explorer machine
+nixops ssh explorer systemctl stop cardano-explorer-node
+nixops ssh explorer systemctl stop postgresql
+
+## Clean up explorer's database
+nixops ssh explorer -- rm -rf /var/lib/postgresql
+## Clean up generator's logs
+nixops ssh explorer -- rm -f /tmp/tx-gen\*.json
+## Clean up node's logs (on all core machines and on explorer machine as well).
+nixops ssh-for-each -- rm -f /var/lib/cardano-node/logs/node-\*.json
+
+## Start postgresql
+nixops ssh explorer systemctl start postgresql
+
+## Start all cardano-nodes (on core machines and on explorer machine as well)
+nixops ssh-for-each systemctl start cardano-node
+
+## Start cardano-explorer-node
+nixops ssh explorer systemctl start cardano-explorer-node

--- a/retrieve_bench_results.sh
+++ b/retrieve_bench_results.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -xe
+
+# Retrieve benchmarking results
+
+CORE_NODES="a b c"
+
+TIMESTAMP=$(date "+%Y-%m-%d-%H%M%S")
+DIR_ON_STAGING_FOR_RESULTS=/tmp/benchmarking-results-$TIMESTAMP
+
+## Create temporary directory for results
+mkdir -p ${DIR_ON_STAGING_FOR_RESULTS}/a
+mkdir -p ${DIR_ON_STAGING_FOR_RESULTS}/b
+mkdir -p ${DIR_ON_STAGING_FOR_RESULTS}/c
+mkdir -p ${DIR_ON_STAGING_FOR_RESULTS}/explorer
+mkdir -p ${DIR_ON_STAGING_FOR_RESULTS}/node-on-explorer
+mkdir -p ${DIR_ON_STAGING_FOR_RESULTS}/generator
+
+## Get and download JSON logs from all core nodes.
+for N in $CORE_NODES
+do
+nixops scp --from $N /var/lib/cardano-node/logs/node-\*.json ${DIR_ON_STAGING_FOR_RESULTS}/${N}/
+done
+
+## Get and download JSON log from the cardano-node working on explorer machine.
+nixops scp --from explorer /var/lib/cardano-node/logs/node-\*.json ${DIR_ON_STAGING_FOR_RESULTS}/node-on-explorer/
+
+## Get and download JSON log from tx generator.
+nixops scp --from explorer /tmp/tx-gen-\*.json ${DIR_ON_STAGING_FOR_RESULTS}/generator/
+
+## Get and download an output from analyse-blocks.sh script.
+CMD="nixops ssh explorer --"
+$CMD "./analyse-blocks.sh" > ${DIR_ON_STAGING_FOR_RESULTS}/explorer/analyse.txt
+
+## Get and download SQL-dump of explorer's database.
+CMD="nixops ssh explorer --"
+$CMD "pg_dump cexplorer -U cexplorer" > ${DIR_ON_STAGING_FOR_RESULTS}/explorer/pg_cexplorer.sql
+gzip -9v ${DIR_ON_STAGING_FOR_RESULTS}/explorer/pg_cexplorer.sql
+
+## Copy revision file
+cp nix/sources.json $DIR_ON_STAGING_FOR_RESULTS/
+
+## Create an archive with results, for more convenient downloading from staging machine.
+tar czf benchmarking-results-${TIMESTAMP}.tgz -C /tmp benchmarking-results-${TIMESTAMP}

--- a/roles/core.nix
+++ b/roles/core.nix
@@ -3,6 +3,7 @@
 with import ../nix {};
 let
   nodeId = config.node.nodeId;
+  leftPad = number: width: lib.fixedWidthString width "0" (toString number);
   signingKey = ../keys/delegate-keys + ".${leftPad nodeId 3}.key";
   delegationCertificate = ../keys/delegation-cert + ".${leftPad nodeId 3}.json";
 

--- a/roles/explorer.nix
+++ b/roles/explorer.nix
@@ -143,7 +143,6 @@ in {
     cluster = globals.environmentName;
   };
   services.cardano-explorer-webapi.enable = true;
-  services.cardano-tx-submit-webapi.enable = lib.mkForce false;
   networking.firewall.allowedTCPPorts = [ 80 443 ];
 
   services.nginx = {

--- a/roles/explorer.nix
+++ b/roles/explorer.nix
@@ -95,6 +95,7 @@ in {
     '';
   };
 
+  services.cardano-explorer.enable = true;
   services.cardano-explorer-webapi.enable = true;
   networking.firewall.allowedTCPPorts = [ 80 443 ];
 

--- a/topologies/shelley-dev.nix
+++ b/topologies/shelley-dev.nix
@@ -11,14 +11,14 @@
       name = "b";
       nodeId = 1;
       org = "IOHK";
-      region = "eu-central-1";
+      region = "ap-southeast-2";
       producers = ["c" "a"];
     }
     {
       name = "c";
       nodeId = 2;
       org = "IOHK";
-      region = "eu-central-1";
+      region = "us-east-1";
       producers = ["a" "b"];
     }
   ];


### PR DESCRIPTION
This forwardports the bits of the `configurable-environments` branch, which were used for the benchmarking deployment.

- deployed on `dev@dev-deployer:~/remote-dev-cluster-3`
- `globals.nix` -> `globals-shelley-dev.nix`