### PR TITLE
Faucet

### DIFF
--- a/clusters/cardano.nix
+++ b/clusters/cardano.nix
@@ -138,7 +138,7 @@ let
       };
       deployment.ec2.region = def.region;
       imports = if globals.withHighLoadRelays then [
-        t3-xlarge ../roles/high-load-relays.nix
+        t3-xlarge ../roles/relay-high-load.nix
       ] else [
         medium ../roles/relay.nix
       ];

--- a/clusters/cardano.nix
+++ b/clusters/cardano.nix
@@ -59,6 +59,15 @@ let
               labels = { alias = "explorer-python-api"; };
             }];
           }
+          {
+            job_name = "cardano-faucet";
+            scrape_interval = "10s";
+            metrics_path = "/metrics";
+            static_configs = [{
+              targets = [ "faucet.${globals.domain}" ];
+              labels = { alias = "cardano-faucet"; };
+            }];
+          }
         ];
       };
     };

--- a/clusters/cardano.nix
+++ b/clusters/cardano.nix
@@ -1,7 +1,10 @@
 { targetEnv
 , medium
 , xlarge
+, t3-xlarge
 , xlarge-monitor
+, c5-2xlarge
+, m5ad-xlarge
 , ...
 }:
 with (import ../nix {});
@@ -59,6 +62,34 @@ let
         ];
       };
     };
+
+    faucet = {
+      deployment.ec2 = {
+        region = "eu-central-1";
+      };
+      imports = [
+        medium
+        ../roles/faucet.nix
+      ];
+      node = {
+        roles.isFaucet = true;
+        org = "IOHK";
+      };
+    };
+
+    # Load client with optimized NVME disks
+    l-a-1 = {
+      deployment.ec2 = {
+        region = "eu-central-1";
+      };
+      imports = [
+        m5ad-xlarge
+        ../roles/load-client.nix
+      ];
+      node = {
+        org = "IOHK";
+      };
+    };
   }) // (lib.optionalAttrs globals.withExplorer {
     explorer = {
       deployment.ec2 = {
@@ -111,8 +142,8 @@ let
       };
       deployment.ec2.region = def.region;
       imports = [
-        medium
-        ../roles/relay.nix
+        t3-xlarge
+        ../roles/relay-high-load.nix
       ];
     };
   };

--- a/deployments/cardano-aws.nix
+++ b/deployments/cardano-aws.nix
@@ -11,12 +11,12 @@ let
 
   cluster = import ../clusters/cardano.nix {
     inherit (aws) targetEnv;
-    medium = aws.t3a-medium;
-    xlarge = aws.t3a-xlarge;
-    t3-xlarge = aws.t3-xlarge;
-    xlarge-monitor = aws.t3a-xlargeMonitor;
-    c5-2xlarge = aws.c5-2xlarge;
-    m5ad-xlarge = aws.m5ad-xlarge;
+    medium = aws.t3a-medium;                     # Standard relay
+    xlarge = aws.t3a-xlarge;                     # Standard explorer
+    t3-xlarge = aws.t3-xlarge;                   # High load relay
+    m5ad-xlarge = aws.m5ad-xlarge;               # Test node
+    xlarge-monitor = aws.t3a-xlargeMonitor;      # Standard monitor
+    t3-2xlarge-monitor = aws.t3-2xlargeMonitor;  # High capacity monitor
   };
 
   nodes = filterAttrs (name: node:

--- a/deployments/cardano-aws.nix
+++ b/deployments/cardano-aws.nix
@@ -13,7 +13,10 @@ let
     inherit (aws) targetEnv;
     medium = aws.t3a-medium;
     xlarge = aws.t3a-xlarge;
+    t3-xlarge = aws.t3-xlarge;
     xlarge-monitor = aws.t3a-xlargeMonitor;
+    c5-2xlarge = aws.c5-2xlarge;
+    m5ad-xlarge = aws.m5ad-xlarge;
   };
 
   nodes = filterAttrs (name: node:
@@ -54,6 +57,10 @@ let
     }
     {
       nodes = (filterAttrs (_: n: n.node.roles.isExplorer or false) nodes);
+      groups = [ allow-public-www-https ];
+    }
+    {
+      nodes = (filterAttrs (_: n: n.node.roles.isFaucet or false) nodes);
       groups = [ allow-public-www-https ];
     }
     {

--- a/globals-defaults.nix
+++ b/globals-defaults.nix
@@ -24,6 +24,9 @@ in {
   withExplorer = true;
   withLegacyExplorer = true;
 
+  withHighCapacityMonitoring = false;
+  withHighLoadRelays = false;
+
   environments = pkgs.iohkNix.cardanoLib.environments;
 
   environmentConfig = pkgs.globals.environments.${pkgs.globals.environmentName};

--- a/globals-defaults.nix
+++ b/globals-defaults.nix
@@ -23,6 +23,7 @@ in {
   withMonitoring = true;
   withExplorer = true;
   withLegacyExplorer = true;
+  withFaucet = false;
 
   withHighCapacityMonitoring = false;
   withHighLoadRelays = false;

--- a/globals-defaults.nix
+++ b/globals-defaults.nix
@@ -14,7 +14,7 @@ in {
 
   environmentName = pkgs.globals.deploymentName;
 
-  dnsZone = "dev.iohkdev.io";
+  dnsZone = "dev.cardano.org";
   domain = "${pkgs.globals.deploymentName}.${pkgs.globals.dnsZone}";
 
   explorerHostName = "explorer";

--- a/globals-mainnet.nix
+++ b/globals-mainnet.nix
@@ -8,6 +8,7 @@ pkgs: {
 
   explorerHostName = "cardano-explorer";
   explorerForceSSL = false;
+  withExplorerAliases = [ "explorer.mainnet.cardano.org" "explorer.cardano.org" ];
 
   withHighCapacityMonitoring = true;
   withHighLoadRelays = true;

--- a/globals-mainnet.nix
+++ b/globals-mainnet.nix
@@ -6,8 +6,8 @@ pkgs: {
 
   domain = "cardano-mainnet.iohk.io";
 
-  explorerHostName = "cardano-explorer";
-  explorerForceSSL = false;
+  explorerHostName = "explorer";
+  explorerForceSSL = true;
   explorerAliases = [ "explorer.mainnet.cardano.org" "explorer.cardano.org" ];
 
   withHighCapacityMonitoring = true;

--- a/globals-mainnet.nix
+++ b/globals-mainnet.nix
@@ -9,6 +9,9 @@ pkgs: {
   explorerHostName = "cardano-explorer";
   explorerForceSSL = false;
 
+  withHighCapacityMonitoring = true;
+  withHighLoadRelays = true;
+
   environmentName = "mainnet";
 
   topology = import ./topologies/mainnet.nix;

--- a/globals-mainnet.nix
+++ b/globals-mainnet.nix
@@ -8,7 +8,7 @@ pkgs: {
 
   explorerHostName = "cardano-explorer";
   explorerForceSSL = false;
-  withExplorerAliases = [ "explorer.mainnet.cardano.org" "explorer.cardano.org" ];
+  explorerAliases = [ "explorer.mainnet.cardano.org" "explorer.cardano.org" ];
 
   withHighCapacityMonitoring = true;
   withHighLoadRelays = true;

--- a/globals-shelley-dev.nix
+++ b/globals-shelley-dev.nix
@@ -2,7 +2,7 @@ pkgs: rec {
 
   withMonitoring = false;
   withLegacyExplorer = false;
-  withExplorerAliases = [];
+  explorerAliases = [];
 
   environmentName = "shelley-dev";
 

--- a/globals-shelley-dev.nix
+++ b/globals-shelley-dev.nix
@@ -2,6 +2,7 @@ pkgs: rec {
 
   withMonitoring = false;
   withLegacyExplorer = false;
+  withExplorerAliases = [];
 
   environmentName = "shelley-dev";
 

--- a/globals-shelley-staging-short.nix
+++ b/globals-shelley-staging-short.nix
@@ -4,6 +4,8 @@ pkgs: {
 
   environmentName = "shelley_staging_short";
 
+  withExplorerAliases = [];
+
   topology = import ./topologies/staging-shelley-short.nix;
 
   ec2 = {

--- a/globals-shelley-staging-short.nix
+++ b/globals-shelley-staging-short.nix
@@ -4,7 +4,7 @@ pkgs: {
 
   environmentName = "shelley_staging_short";
 
-  withExplorerAliases = [];
+  explorerAliases = [];
 
   topology = import ./topologies/staging-shelley-short.nix;
 

--- a/globals-shelley-staging.nix
+++ b/globals-shelley-staging.nix
@@ -4,7 +4,7 @@ pkgs: {
 
   environmentName = "shelley_staging";
 
-  withExplorerAliases = [];
+  explorerAliases = [];
 
   withFaucet = true;
   faucetHostname = "faucet";

--- a/globals-shelley-staging.nix
+++ b/globals-shelley-staging.nix
@@ -4,6 +4,11 @@ pkgs: {
 
   environmentName = "shelley_staging";
 
+  withFaucet = true;
+  faucetHostname = "faucet";
+
+  withHighLoadRelays = true;
+
   topology = import ./topologies/staging-shelley.nix;
 
   ec2 = {

--- a/globals-shelley-staging.nix
+++ b/globals-shelley-staging.nix
@@ -4,6 +4,8 @@ pkgs: {
 
   environmentName = "shelley_staging";
 
+  withExplorerAliases = [];
+
   withFaucet = true;
   faucetHostname = "faucet";
 

--- a/globals-staging.nix
+++ b/globals-staging.nix
@@ -8,6 +8,8 @@ pkgs: {
 
   environmentName = "staging";
 
+  withExplorerAliases = [];
+
   topology = import ./topologies/staging.nix;
 
   ec2 = {

--- a/globals-staging.nix
+++ b/globals-staging.nix
@@ -8,7 +8,8 @@ pkgs: {
 
   environmentName = "staging";
 
-  withExplorerAliases = [];
+  explorerAliases = [];
+  withHighLoadRelays = true;
 
   topology = import ./topologies/staging.nix;
 

--- a/globals-testnet.nix
+++ b/globals-testnet.nix
@@ -6,6 +6,7 @@ pkgs: {
 
   domain = "cardano-testnet.iohkdev.io";
 
+  withExplorerAliases = [];
   withFaucet = true;
   faucetHostname = "faucet2";
 

--- a/globals-testnet.nix
+++ b/globals-testnet.nix
@@ -6,7 +6,7 @@ pkgs: {
 
   domain = "cardano-testnet.iohkdev.io";
 
-  withExplorerAliases = [];
+  explorerAliases = [];
   withFaucet = true;
   faucetHostname = "faucet2";
 

--- a/globals-testnet.nix
+++ b/globals-testnet.nix
@@ -6,6 +6,9 @@ pkgs: {
 
   domain = "cardano-testnet.iohkdev.io";
 
+  withFaucet = true;
+  faucetHostname = "faucet2";
+
   environmentName = "testnet";
 
   topology = import ./topologies/testnet.nix;

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -30,6 +30,7 @@ in {
         isByronProxy = boolOption;
         isMonitor = boolOption;
         isExplorer = boolOption;
+        isFaucet = boolOption;
       };
     };
   };

--- a/modules/grafana/cardano/cardano-byron-reboot.json
+++ b/modules/grafana/cardano/cardano-byron-reboot.json
@@ -1,0 +1,1583 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 33,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 27,
+      "panels": [],
+      "title": "TCP Connections",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "CurrEstab - TCP connections for which the current state is either ESTABLISHED or CLOSE-WAIT",
+      "fill": 2,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 25,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "node_netstat_Tcp_CurrEstab{alias=~\"e-a-.*\"}",
+          "intervalFactor": 2,
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Frankfurt TCP connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "CurrEstab - TCP connections for which the current state is either ESTABLISHED or CLOSE-WAIT",
+      "fill": 2,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 28,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "node_netstat_Tcp_CurrEstab{alias=~\"e-b-.*\"}",
+          "intervalFactor": 2,
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Tokyo TCP connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "CurrEstab - TCP connections for which the current state is either ESTABLISHED or CLOSE-WAIT",
+      "fill": 2,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 29,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "node_netstat_Tcp_CurrEstab{alias=~\"e-c-.*\"}",
+          "intervalFactor": 2,
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Singapore TCP connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "CurrEstab - TCP connections for which the current state is either ESTABLISHED or CLOSE-WAIT",
+      "fill": 2,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 30,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "node_netstat_Tcp_CurrEstab{alias=~\"e-d-.*\"}",
+          "intervalFactor": 2,
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Ohio TCP connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 23,
+      "title": "Edge Node CPU% and Free Mem%",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 21,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "100 - (avg by(alias) (irate(node_cpu_seconds_total{alias=~\"e-.*\",mode=\"idle\"}[1m])) * 100)",
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Edge Node CPU Utilization (1m avg)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Counts memory that is free as well as reclaimable from caches and buffers",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 19,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "node_memory_MemAvailable_bytes{alias=~\"e-.*\"} / node_memory_MemTotal_bytes{alias=~\"e-.*\"} * 100",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Edge Node Memory Available (%)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 16,
+      "panels": [],
+      "title": "Edge Node Region Aggregate Bandwidth and BlockNum",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 14,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(node_network_transmit_bytes_total{alias=~\"e-a-.*\",device!~\"lo\"}[20s]) * -8)",
+          "legendFormat": "Frankfurt Egress",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(node_network_transmit_bytes_total{alias=~\"e-b-.*\",device!~\"lo\"}[20s]) * -8)",
+          "legendFormat": "Tokyo Egress",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(node_network_transmit_bytes_total{alias=~\"e-c-.*\",device!~\"lo\"}[20s]) * -8)",
+          "legendFormat": "Singapore Egress",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(node_network_transmit_bytes_total{alias=~\"e-d-.*\",device!~\"lo\"}[20s]) * -8)",
+          "legendFormat": "Ohio Egress",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(node_network_receive_bytes_total{alias=~\"e-a-.*\",device!~\"lo\"}[20s]) * 8)",
+          "legendFormat": "Frankfurt Ingress",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(rate(node_network_receive_bytes_total{alias=~\"e-b-.*\",device!~\"lo\"}[20s]) * 8)",
+          "legendFormat": "Tokyo Ingress",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(rate(node_network_receive_bytes_total{alias=~\"e-c-.*\",device!~\"lo\"}[20s]) * 8)",
+          "legendFormat": "Singapore Ingress",
+          "refId": "G"
+        },
+        {
+          "expr": "sum(rate(node_network_receive_bytes_total{alias=~\"e-d-.*\",device!~\"lo\"}[20s]) * 8)",
+          "legendFormat": "Ohio Ingress",
+          "refId": "H"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Region Aggregate Bandwidth Comparison (bps)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbits",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 17,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "cardano_node_ChainDB_metrics_blockNum_int{alias=~\"e-.*\"}",
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "EdgeNode BlockNum",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Edge Node Egress Bandwidth",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 45
+      },
+      "id": 2,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(node_network_transmit_bytes_total{alias=~\"e-a-.*\",device!~\"lo\"}[20s]) * -8",
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Frankfurt Edge Node Egress Bandwidth (bps)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbits",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 45
+      },
+      "id": 3,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(node_network_transmit_bytes_total{alias=~\"e-b-.*\",device!~\"lo\"}[20s]) * -8",
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Tokyo Edge Node Egress Bandwidth (bps)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbits",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 56
+      },
+      "id": 4,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(node_network_transmit_bytes_total{alias=~\"e-c-.*\",device!~\"lo\"}[20s]) * -8",
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Singapore Edge Node Egress Bandwidth (bps)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbits",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 56
+      },
+      "id": 5,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(node_network_transmit_bytes_total{alias=~\"e-d-.*\",device!~\"lo\"}[20s]) * -8",
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Ohio Edge Node Egress Bandwidth (bps)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbits",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 67
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Edge Node Ingress Bandwidth",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 68
+      },
+      "id": 6,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(node_network_receive_bytes_total{alias=~\"e-a-.*\",device!~\"lo\"}[20s]) * 8",
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Frankfurt Edge Node Ingress Bandwidth (bps)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbits",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 68
+      },
+      "id": 7,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(node_network_receive_bytes_total{alias=~\"e-b-.*\",device!~\"lo\"}[20s]) * 8",
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Tokyo Edge Node Ingress Bandwidth (bps)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbits",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 79
+      },
+      "id": 8,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(node_network_receive_bytes_total{alias=~\"e-c-.*\",device!~\"lo\"}[20s]) * 8",
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Singapore Edge Node Ingress Bandwidth (bps)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbits",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 79
+      },
+      "id": 9,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(node_network_receive_bytes_total{alias=~\"e-d-.*\",device!~\"lo\"}[20s]) * 8",
+          "legendFormat": "{{alias}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Ohio Edge Node Ingress Bandwidth (bps)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbits",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 20,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Byron-Reboot Monitoring",
+  "uid": "HvGFvr9Wk",
+  "version": 11
+}

--- a/modules/load-client.nix
+++ b/modules/load-client.nix
@@ -1,0 +1,55 @@
+{ pkgs, config, lib, nodes, name, ... }:
+with (import ../nix {}); with lib;
+let
+  iohkNix = import sourcePaths.iohk-nix {};
+  cfg = config.services.cardano-node;
+  nodePort = globals.cardanoNodePort;
+  hostAddr = getListenIp nodes.${name};
+  monitoringPort = globals.cardanoNodePrometheusExporterPort;
+in
+{
+  imports = [
+    ./common.nix
+    (sourcePaths.cardano-node + "/nix/nixos")
+  ];
+
+  networking.firewall = {
+    allowedTCPPorts = [ nodePort monitoringPort ];
+
+    # TODO: securing this depends on CSLA-27
+    # NOTE: this implicitly blocks DHCPCD, which uses port 68
+    allowedUDPPortRanges = [ { from = 1024; to = 65000; } ];
+  };
+
+  services.cardano-node = {
+    enable = true;
+    extraArgs = [ "+RTS" "-N2" "-A10m" "-qg" "-qb" "-M3G" "-RTS" ];
+    environment = globals.environmentName;
+    port = nodePort;
+    environments = {
+      "${globals.environmentName}" = globals.environmentConfig;
+    };
+    nodeConfig = globals.environmentConfig.nodeConfig // {
+      hasPrometheus = [ hostAddr globals.cardanoNodePrometheusExporterPort ];
+      # Use Journald output:
+      defaultScribes = [
+        [
+          "JournalSK"
+          "cardano"
+        ]
+      ];
+    };
+    topology = iohkNix.cardanoLib.mkEdgeTopology {
+      inherit (cfg) port;
+      edgeHost = iohkNix.cardanoLib.environments."${globals.environmentName}".relaysNew;
+      edgeNodes = [];
+    };
+  };
+  systemd.services.cardano-node.serviceConfig.MemoryMax = "3.5G";
+  # TODO remove next two line for next release cardano-node 1.7 release:
+  systemd.services.cardano-node.preStart = ''
+    if [ -d ${cfg.databasePath}-${toString cfg.nodeId} ]; then
+      mv ${cfg.databasePath}-${toString cfg.nodeId} ${cfg.databasePath}
+    fi
+  '';
+}

--- a/modules/load-client.nix
+++ b/modules/load-client.nix
@@ -1,7 +1,6 @@
 { pkgs, config, lib, nodes, name, ... }:
 with (import ../nix {}); with lib;
 let
-  iohkNix = import sourcePaths.iohk-nix {};
   cfg = config.services.cardano-node;
   nodePort = globals.cardanoNodePort;
   hostAddr = getListenIp nodes.${name};

--- a/modules/monitoring-cardano.nix
+++ b/modules/monitoring-cardano.nix
@@ -52,50 +52,50 @@
   ] ++ (builtins.concatMap ({region, regionLetter}: [
     {
       alert = "high_tcp_connections_${region}";
-      expr = "avg(node_netstat_Tcp_CurrEstab{alias=~\"e-${regionLetter}-.*\"}) - count(count(node_netstat_Tcp_CurrEstab{alias=~\"e-${regionLetter}-.*\"}) by (alias)) > 36";
+      expr = "avg(node_netstat_Tcp_CurrEstab{alias=~\"e-${regionLetter}-.*\"}) - count(count(node_netstat_Tcp_CurrEstab{alias=~\"e-${regionLetter}-.*\"}) by (alias)) > 60";
       for = "5m";
       labels = {
         severity = "page";
       };
       annotations = {
-        summary = "${region}: Average connection per nodes higher than 36 for more than 5 minutes.";
-        description = "${region}: Average connection per nodes higher than 36 for more than 5 minutes. Adding new nodes to that region might soon be required.";
+        summary = "${region}: Average connection per nodes higher than 60 for more than 5 minutes.";
+        description = "${region}: Average connection per nodes higher than 60 for more than 5 minutes. Adding new nodes to that region might soon be required.";
       };
     }
     {
       alert = "critical_tcp_connections_${region}";
-      expr = "avg(node_netstat_Tcp_CurrEstab{alias=~\"e-${regionLetter}-.*\"}) - count(count(node_netstat_Tcp_CurrEstab{alias=~\"e-${regionLetter}-.*\"}) by (alias)) > 40";
+      expr = "avg(node_netstat_Tcp_CurrEstab{alias=~\"e-${regionLetter}-.*\"}) - count(count(node_netstat_Tcp_CurrEstab{alias=~\"e-${regionLetter}-.*\"}) by (alias)) > 80";
       for = "15m";
       labels = {
         severity = "page";
       };
       annotations = {
-        summary = "${region}: Average connection per nodes higher than 40 for more than 15 minutes.";
-        description = "${region}: Average connection per nodes higher than 40 for more than 15 minutes. Adding new nodes to that region IS required.";
+        summary = "${region}: Average connection per nodes higher than 80 for more than 15 minutes.";
+        description = "${region}: Average connection per nodes higher than 80 for more than 15 minutes. Adding new nodes to that region IS required.";
       };
     }
     {
       alert = "high_egress_${region}";
-      expr = "avg(rate(node_network_transmit_bytes_total{alias=~\"e-${regionLetter}-.*\",device!~\"lo\"}[20s]) * 8) > 6 * 1000 * 1000";
+      expr = "avg(rate(node_network_transmit_bytes_total{alias=~\"e-${regionLetter}-.*\",device!~\"lo\"}[20s]) * 8) > 275 * 1000 * 1000";
       for = "5m";
       labels = {
         severity = "page";
       };
       annotations = {
-        summary = "${region}: Average egress throughput is higher than 6 Mibs for more than 5 minutes.";
-        description = "${region}: Average egress throughput is higher than 6 Mibs for more than 5 minutes. Adding new nodes to that region might soon be required.";
+        summary = "${region}: Average egress throughput is higher than 275 Mbps for more than 5 minutes.";
+        description = "${region}: Average egress throughput is higher than 275 Mbps for more than 5 minutes. Adding new nodes to that region might soon be required.";
       };
     }
     {
       alert = "critical_egress_${region}";
-      expr = "avg(rate(node_network_transmit_bytes_total{alias=~\"e-${regionLetter}-.*\",device!~\"lo\"}[20s]) * 8) > 7 * 1000 * 1000";
+      expr = "avg(rate(node_network_transmit_bytes_total{alias=~\"e-${regionLetter}-.*\",device!~\"lo\"}[20s]) * 8) > 350 * 1000 * 1000";
       for = "15m";
       labels = {
         severity = "page";
       };
       annotations = {
-        summary = "${region}: Average egress throughput is higher than 7 Mibs for more than 15 minutes.";
-        description = "${region}: Average egress throughput is higher than 7 Mibs for more than 15 minutes. Adding new nodes to that region IS required.";
+        summary = "${region}: Average egress throughput is higher than 350 Mbps for more than 15 minutes.";
+        description = "${region}: Average egress throughput is higher than 350 Mbps for more than 15 minutes. Adding new nodes to that region IS required.";
       };
     }])
   [{ region = "eu-central-1";   regionLetter = "a"; }

--- a/modules/monitoring-cardano.nix
+++ b/modules/monitoring-cardano.nix
@@ -76,26 +76,26 @@
     }
     {
       alert = "high_egress_${region}";
-      expr = "avg(rate(node_network_transmit_bytes_total{alias=~\"e-${regionLetter}-.*\",device!~\"lo\"}[20s]) * 8) > 275 * 1000 * 1000";
+      expr = "avg(rate(node_network_transmit_bytes_total{alias=~\"e-${regionLetter}-.*\",device!~\"lo\"}[20s]) * 8) > 150 * 1000 * 1000";
       for = "5m";
       labels = {
         severity = "page";
       };
       annotations = {
-        summary = "${region}: Average egress throughput is higher than 275 Mbps for more than 5 minutes.";
-        description = "${region}: Average egress throughput is higher than 275 Mbps for more than 5 minutes. Adding new nodes to that region might soon be required.";
+        summary = "${region}: Average egress throughput is higher than 150 Mbps for more than 5 minutes.";
+        description = "${region}: Average egress throughput is higher than 150 Mbps for more than 5 minutes. Adding new nodes to that region might soon be required.";
       };
     }
     {
       alert = "critical_egress_${region}";
-      expr = "avg(rate(node_network_transmit_bytes_total{alias=~\"e-${regionLetter}-.*\",device!~\"lo\"}[20s]) * 8) > 350 * 1000 * 1000";
+      expr = "avg(rate(node_network_transmit_bytes_total{alias=~\"e-${regionLetter}-.*\",device!~\"lo\"}[20s]) * 8) > 200 * 1000 * 1000";
       for = "15m";
       labels = {
         severity = "page";
       };
       annotations = {
-        summary = "${region}: Average egress throughput is higher than 350 Mbps for more than 15 minutes.";
-        description = "${region}: Average egress throughput is higher than 350 Mbps for more than 15 minutes. Adding new nodes to that region IS required.";
+        summary = "${region}: Average egress throughput is higher than 200 Mbps for more than 15 minutes.";
+        description = "${region}: Average egress throughput is higher than 200 Mbps for more than 15 minutes. Adding new nodes to that region IS required.";
       };
     }])
   [{ region = "eu-central-1";   regionLetter = "a"; }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-faucet",
-        "rev": "9132ecb80928ea1627da146f4c87b99eba5906fa",
-        "sha256": "11vp3pisabc0sy2xq2b0s96rgcd524fmmr1mr8x94l0hyf9mmn2b",
+        "rev": "8a7e735d9564ef0f893da81eb826875d95dd6a2b",
+        "sha256": "1ngfr9lycj6124mnjl80sclkq8i6gl1zfibmzlvfbm75s2zhhljw",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-faucet/archive/9132ecb80928ea1627da146f4c87b99eba5906fa.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-faucet/archive/8a7e735d9564ef0f893da81eb826875d95dd6a2b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-graphql": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -48,15 +48,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node": {
-        "branch": "tags/1.10.0",
+        "branch": "tags/1.9.3",
         "description": null,
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "76d321b7cb217795e78620eede4ffc239727bcb1",
-        "sha256": "1xyax2i7wb1a2kh1x3q81n1ay1fvq651innaxx3n2q1grl88s4zi",
+        "rev": "b0c7d4457704a46167687f519f2e0f315ab5abd4",
+        "sha256": "1mkaxx92fc8hi3bpsazlqs6nc89g0bz3rg6wrlkrlrqnwn1xkdj8",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/76d321b7cb217795e78620eede4ffc239727bcb1.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/b0c7d4457704a46167687f519f2e0f315ab5abd4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-rest": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-faucet",
-        "rev": "8a7e735d9564ef0f893da81eb826875d95dd6a2b",
-        "sha256": "1ngfr9lycj6124mnjl80sclkq8i6gl1zfibmzlvfbm75s2zhhljw",
+        "rev": "62264d94b990d865b395ed5501eeb6cccda05a7a",
+        "sha256": "0jhhxwzkjidfq5am36ah5cx06ijwp22babzpgiw5v5yb7ldbk2g4",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-faucet/archive/8a7e735d9564ef0f893da81eb826875d95dd6a2b.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-faucet/archive/62264d94b990d865b395ed5501eeb6cccda05a7a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-graphql": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -48,15 +48,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node": {
-        "branch": "tags/1.9.3",
+        "branch": "tags/1.10.0",
         "description": null,
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "b0c7d4457704a46167687f519f2e0f315ab5abd4",
-        "sha256": "1mkaxx92fc8hi3bpsazlqs6nc89g0bz3rg6wrlkrlrqnwn1xkdj8",
+        "rev": "76d321b7cb217795e78620eede4ffc239727bcb1",
+        "sha256": "1xyax2i7wb1a2kh1x3q81n1ay1fvq651innaxx3n2q1grl88s4zi",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/b0c7d4457704a46167687f519f2e0f315ab5abd4.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/76d321b7cb217795e78620eede4ffc239727bcb1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-rest": {
@@ -113,10 +113,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "50eb9c4ececf383309ada328545b788c3493cd42",
-        "sha256": "0hz5rlzb92cyk3z93p7ms538c33c4a7znlgv03aijcih2fwflyqr",
+        "rev": "5193306abf61cc902cd4e71501b35daf0703373e",
+        "sha256": "0cfj35wpahxp0kjwcz1nl6vl1pkdz7g19vcid093kq0lnp721nsi",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/50eb9c4ececf383309ada328545b788c3493cd42.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/5193306abf61cc902cd4e71501b35daf0703373e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -149,10 +149,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "ops-lib",
-        "rev": "0bfb4eb15c6a1b4559ae4c4c037dc52566a01d7b",
-        "sha256": "144fbx8qpjsn5dvrv9l5pl7dc84faaajgszzg5yqcpgfqakrqyii",
+        "rev": "28a134afad0393b1adc824efbd41c1ba9fe80011",
+        "sha256": "1bwyhz3v0vj6d6r4v417vgb6v9gsz5im0hbsfxbmxfz1s7z295l2",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/ops-lib/archive/0bfb4eb15c6a1b4559ae4c4c037dc52566a01d7b.tar.gz",
+        "url": "https://github.com/input-output-hk/ops-lib/archive/28a134afad0393b1adc824efbd41c1ba9fe80011.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -149,10 +149,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "ops-lib",
-        "rev": "28a134afad0393b1adc824efbd41c1ba9fe80011",
-        "sha256": "1bwyhz3v0vj6d6r4v417vgb6v9gsz5im0hbsfxbmxfz1s7z295l2",
+        "rev": "77bfb55573c269ae631bd88d94902759318667f8",
+        "sha256": "09jb03lpx09y00qis35b2hh4mlz0i6cpfqm8m70pi491ijp5xrr7",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/ops-lib/archive/28a134afad0393b1adc824efbd41c1ba9fe80011.tar.gz",
+        "url": "https://github.com/input-output-hk/ops-lib/archive/77bfb55573c269ae631bd88d94902759318667f8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-faucet",
-        "rev": "c0ebb0545b3f7ed80534cef5c961e9dfa632c396",
-        "sha256": "0v9msixq8bl48p8bmjcawf73khd0cg51mb5rdsfqi6yj0nx9mg57",
+        "rev": "9132ecb80928ea1627da146f4c87b99eba5906fa",
+        "sha256": "11vp3pisabc0sy2xq2b0s96rgcd524fmmr1mr8x94l0hyf9mmn2b",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-faucet/archive/c0ebb0545b3f7ed80534cef5c961e9dfa632c396.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-faucet/archive/9132ecb80928ea1627da146f4c87b99eba5906fa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-graphql": {
@@ -113,10 +113,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "5193306abf61cc902cd4e71501b35daf0703373e",
-        "sha256": "0cfj35wpahxp0kjwcz1nl6vl1pkdz7g19vcid093kq0lnp721nsi",
+        "rev": "50eb9c4ececf383309ada328545b788c3493cd42",
+        "sha256": "0hz5rlzb92cyk3z93p7ms538c33c4a7znlgv03aijcih2fwflyqr",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/5193306abf61cc902cd4e71501b35daf0703373e.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/50eb9c4ececf383309ada328545b788c3493cd42.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -23,6 +23,18 @@
         "url": "https://github.com/input-output-hk/cardano-db-sync/archive/be2fb8ae73c3ad872de0ad80621bca4718b64b25.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "cardano-faucet": {
+        "branch": "master",
+        "description": "Faucet for Cardano",
+        "homepage": null,
+        "owner": "input-output-hk",
+        "repo": "cardano-faucet",
+        "rev": "c0ebb0545b3f7ed80534cef5c961e9dfa632c396",
+        "sha256": "0v9msixq8bl48p8bmjcawf73khd0cg51mb5rdsfqi6yj0nx9mg57",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/cardano-faucet/archive/c0ebb0545b3f7ed80534cef5c961e9dfa632c396.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "cardano-graphql": {
         "branch": "master",
         "description": "GraphQL API for Cardano",
@@ -137,10 +149,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "ops-lib",
-        "rev": "953940b3539a69e8c0c3ee4cc5427c1b9c5f8d64",
-        "sha256": "18m2km2hf51hv3jf55z6nklrj6vjhzg1wr7r7a0mvjyl0bfh7aaq",
+        "rev": "0bfb4eb15c6a1b4559ae4c4c037dc52566a01d7b",
+        "sha256": "144fbx8qpjsn5dvrv9l5pl7dc84faaajgszzg5yqcpgfqakrqyii",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/ops-lib/archive/953940b3539a69e8c0c3ee4cc5427c1b9c5f8d64.tar.gz",
+        "url": "https://github.com/input-output-hk/ops-lib/archive/0bfb4eb15c6a1b4559ae4c4c037dc52566a01d7b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/roles/byron-proxy.nix
+++ b/roles/byron-proxy.nix
@@ -52,7 +52,6 @@ in {
           "${globals.environmentName}" = globals.environmentConfig;
         };
       };
-      pbftThreshold = "0.5";
       environment = globals.environmentName;
       nodeId = name;
       proxyHost = legacyCardanoCfg.listenIp;

--- a/roles/byron-proxy.nix
+++ b/roles/byron-proxy.nix
@@ -52,6 +52,7 @@ in {
           "${globals.environmentName}" = globals.environmentConfig;
         };
       };
+      pbftThreshold = "0.5";
       environment = globals.environmentName;
       nodeId = name;
       proxyHost = legacyCardanoCfg.listenIp;

--- a/roles/explorer-legacy.nix
+++ b/roles/explorer-legacy.nix
@@ -57,6 +57,7 @@ in {
       # mkForce the explorer virtual machine config to override
       # the new explorer only nginx config
       "${globals.explorerHostName}.${globals.domain}" = mkForce {
+        serverAliases = globals.withExplorerAliases;
         enableACME = true;
         forceSSL = globals.explorerForceSSL;
         locations = {

--- a/roles/explorer-legacy.nix
+++ b/roles/explorer-legacy.nix
@@ -57,7 +57,7 @@ in {
       # mkForce the explorer virtual machine config to override
       # the new explorer only nginx config
       "${globals.explorerHostName}.${globals.domain}" = mkForce {
-        serverAliases = globals.withExplorerAliases;
+        serverAliases = globals.explorerAliases;
         enableACME = true;
         forceSSL = globals.explorerForceSSL;
         locations = {

--- a/roles/explorer.nix
+++ b/roles/explorer.nix
@@ -96,7 +96,7 @@ in {
     recommendedProxySettings = true;
     virtualHosts = {
       "${globals.explorerHostName}.${globals.domain}" = {
-        serverAliases = globals.withExplorerAliases;
+        serverAliases = globals.explorerAliases;
         enableACME = true;
         forceSSL = globals.explorerForceSSL;
         locations = {

--- a/roles/explorer.nix
+++ b/roles/explorer.nix
@@ -96,6 +96,7 @@ in {
     recommendedProxySettings = true;
     virtualHosts = {
       "${globals.explorerHostName}.${globals.domain}" = {
+        serverAliases = globals.withExplorerAliases;
         enableACME = true;
         forceSSL = globals.explorerForceSSL;
         locations = {

--- a/roles/faucet.nix
+++ b/roles/faucet.nix
@@ -30,9 +30,16 @@ in {
 
   services.cardano-faucet = {
     enable = true;
-    cardanoEnv = "shelley_staging";
-    faucetLogLevel = "DEBUG";
-    secondsBetweenRequests = 3600;
+    cardanoEnv = globals.environmentName;
+
+    # Defaults to 1000 ADA per request
+    #lovelacesToGive = 1000000000;
+
+    # Defaults to INFO
+    #faucetLogLevel = "DEBUG";
+
+    # Defaults to a 1 day rate request limit, exemptable by API key
+    #secondsBetweenRequests = 3600;
   };
 
   deployment.keys = {

--- a/roles/faucet.nix
+++ b/roles/faucet.nix
@@ -12,8 +12,6 @@ in {
     (sourcePaths.cardano-faucet + "/nix/nixos")
   ];
 
-  users.users.cardano-node.extraGroups = [ "keys" ];
-
   environment.systemPackages = with pkgs; [
     faucetPkgs.cardano-wallet-byron
     jq
@@ -65,6 +63,8 @@ in {
     };
   };
 
+  # NOTE: Cardano Faucet maintains its own cardano-node niv pin which is used here
+  users.users.cardano-node.extraGroups = [ "keys" ];
   services.cardano-node.nodeConfig = globals.environmentConfig.nodeConfig // {
     hasPrometheus = [ hostAddr monitoringPort ];
   };

--- a/roles/faucet.nix
+++ b/roles/faucet.nix
@@ -1,0 +1,131 @@
+{ name, config, nodes, resources, ... }:
+with import ../nix {};
+let
+  faucetPkgs = (import (sourcePaths.cardano-faucet + "/nix") {}).pkgs;
+  hostAddr = getListenIp nodes.${name};
+  nodePort = globals.cardanoNodePort;
+  monitoringPort = globals.cardanoNodePrometheusExporterPort;
+in {
+
+  imports = [
+    ../modules/common.nix
+    (sourcePaths.cardano-faucet + "/nix/nixos")
+  ];
+
+  users.users.cardano-node.extraGroups = [ "keys" ];
+
+  environment.systemPackages = with pkgs; [
+    faucetPkgs.cardano-wallet-byron
+    jq
+  ];
+
+  networking.firewall.allowedTCPPorts = [
+    80
+    443
+    nodePort
+    monitoringPort
+  ];
+
+  services.monitoring-exporters.extraPrometheusExportersPorts = [ monitoringPort ];
+
+  services.cardano-faucet = {
+    enable = true;
+    cardanoEnv = "shelley_staging";
+    faucetLogLevel = "DEBUG";
+    secondsBetweenRequests = 10;
+  };
+
+  deployment.keys = {
+    "faucet.mnemonic" = {
+      keyFile = ../static + "/faucet.mnemonic";
+      destDir = "/var/lib/keys/";
+      user = "cardano-node";
+      permissions = "0400";
+    };
+
+    "faucet.passphrase" = {
+      keyFile = ../static + "/faucet.passphrase";
+      destDir = "/var/lib/keys/";
+      user = "cardano-node";
+      permissions = "0400";
+    };
+  };
+
+  services.cardano-node.nodeConfig = globals.environmentConfig.nodeConfig // {
+    hasPrometheus = [ hostAddr monitoringPort ];
+  };
+
+  services.nginx = {
+    enable = true;
+    recommendedTlsSettings = true;
+    recommendedOptimisation = true;
+    recommendedGzipSettings = true;
+    recommendedProxySettings = true;
+    serverTokens = false;
+    mapHashBucketSize = 128;
+
+    commonHttpConfig = ''
+      log_format x-fwd '$remote_addr - $remote_user [$time_local] '
+                        '"$request" $status $body_bytes_sent '
+                        '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+      access_log syslog:server=unix:/dev/log x-fwd;
+      limit_req_zone $binary_remote_addr zone=faucetPerIP:100m rate=1r/s;
+      limit_req_status 429;
+      server_names_hash_bucket_size 128;
+
+      map $http_origin $origin_allowed {
+        default 0;
+        https://webdevc.iohk.io 1;
+        http://webdevc.iohk.io 1;
+        https://webdevr.iohk.io 1;
+        http://webdevr.iohk.io 1;
+        https://testnet.iohkdev.io 1;
+        http://127.0.0.1:4000 1;
+      }
+
+      map $origin_allowed $origin {
+        default "";
+        1 $http_origin;
+      }
+    '';
+
+    virtualHosts = {
+      "${name}.${globals.domain}" = {
+        forceSSL = config.deployment.targetEnv != "libvirtd";
+        enableACME = config.deployment.targetEnv != "libvirtd";
+
+        locations."/" = {
+          extraConfig = let
+            headers = ''
+              add_header 'Vary' 'Origin' always;
+              add_header 'Access-Control-Allow-Origin' $origin always;
+              add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS' always;
+              add_header 'Access-Control-Allow-Headers' 'User-Agent,X-Requested-With,Content-Type' always;
+            '';
+          in ''
+            limit_req zone=faucetPerIP;
+
+            if ($request_method = OPTIONS) {
+              ${headers}
+              add_header 'Access-Control-Max-Age' 1728000;
+              add_header 'Content-Type' 'text/plain; charset=utf-8';
+              add_header 'Content-Length' 0;
+              return 204;
+              break;
+            }
+
+            if ($request_method = POST) {
+              ${headers}
+            }
+
+            proxy_pass http://127.0.0.1:${
+              toString config.services.cardano-faucet.faucetListenPort
+            };
+            proxy_set_header Host $host:$server_port;
+            proxy_set_header X-Real-IP $remote_addr;
+          '';
+        };
+      };
+    };
+  };
+}

--- a/roles/faucet.nix
+++ b/roles/faucet.nix
@@ -32,7 +32,7 @@ in {
     enable = true;
     cardanoEnv = "shelley_staging";
     faucetLogLevel = "DEBUG";
-    secondsBetweenRequests = 10;
+    secondsBetweenRequests = 3600;
   };
 
   deployment.keys = {
@@ -45,6 +45,13 @@ in {
 
     "faucet.passphrase" = {
       keyFile = ../static + "/faucet.passphrase";
+      destDir = "/var/lib/keys/";
+      user = "cardano-node";
+      permissions = "0400";
+    };
+
+    "faucet.apikey" = {
+      keyFile = ../static + "/faucet.apikey";
       destDir = "/var/lib/keys/";
       user = "cardano-node";
       permissions = "0400";

--- a/roles/load-client.nix
+++ b/roles/load-client.nix
@@ -1,0 +1,67 @@
+{ config, pkgs, ... }:
+{
+  imports = [
+    ../modules/load-client.nix
+  ];
+
+  systemd.services.cardano-node.after = [ "ephemeral.service" ];
+
+  # Configure high IOPS on any ec2 node supporting it for cardano-node load client
+  systemd.services.ephemeral = {
+    wantedBy = [ "multi-user.target" ];
+    before = [ "cardano-node.service" "sshd.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+    };
+    path = with pkgs; [
+      coreutils
+      e2fsprogs
+      gnugrep
+      gnused
+      gnutar
+      kmod
+      mdadm
+      utillinux
+    ];
+    script = let
+      replacePath = "/var/lib/cardano-node";
+    in ''
+      #!/run/current-system/sw/bin/bash
+      # This script should work on any ec2 instance which has an EBS nvme0n1 root vol and additional
+      # non-EBS local nvme[1-9]n1 ephemeral block storage devices, ex: c5, g4, i3, m5, r5, x1, z1.
+      set -x
+      df | grep -q /var/lib/cardano-node && { echo "/var/lib/cardano-node is pre-mounted, exiting."; exit 0; }
+      mapfile -t DEVS < <(find /dev -maxdepth 1 -regextype posix-extended -regex ".*/nvme[1-9]n1")
+      [ "''${#DEVS[@]}" -eq "0" ] && { echo "No additional NVME found, exiting."; exit 0; }
+      if [ -d ${replacePath} ]; then
+        mv ${replacePath} ${replacePath}-backup
+      fi
+      mkdir -p ${replacePath}
+      if [ "''${#DEVS[@]}" -gt "1" ]; then
+        mdadm --create --verbose --auto=yes /dev/md0 --level=0 --raid-devices="''${#DEVS[@]}" "''${DEVS[@]}"
+        mkfs.ext4 /dev/md0
+        mount /dev/md0 ${replacePath}
+      elif [ "''${#DEVS[@]}" -eq "1" ]; then
+        mkfs.ext4 "''${DEVS[@]}"
+        mount "''${DEVS[@]}" ${replacePath}
+      fi
+      if [ -d ${replacePath}-backup ]; then
+        mv ${replacePath}-backup/* ${replacePath}/
+      fi
+      set +x
+    '';
+  };
+
+  services.netdata = {
+    enable = true;
+    config = {
+      global = {
+        "default port" = "19999";
+        "bind to" = "*";
+        "history" = "86400";
+        "error log" = "syslog";
+        "debug log" = "syslog";
+      };
+    };
+  };
+}

--- a/roles/load-client.nix
+++ b/roles/load-client.nix
@@ -30,7 +30,7 @@
       # This script should work on any ec2 instance which has an EBS nvme0n1 root vol and additional
       # non-EBS local nvme[1-9]n1 ephemeral block storage devices, ex: c5, g4, i3, m5, r5, x1, z1.
       set -x
-      df | grep -q /var/lib/cardano-node && { echo "/var/lib/cardano-node is pre-mounted, exiting."; exit 0; }
+      df | grep -q ${replacePath} && { echo "${replacePath} is pre-mounted, exiting."; exit 0; }
       mapfile -t DEVS < <(find /dev -maxdepth 1 -regextype posix-extended -regex ".*/nvme[1-9]n1")
       [ "''${#DEVS[@]}" -eq "0" ] && { echo "No additional NVME found, exiting."; exit 0; }
       if [ -d ${replacePath} ]; then

--- a/roles/relay-high-load.nix
+++ b/roles/relay-high-load.nix
@@ -1,0 +1,31 @@
+{ lib, config, ... }:
+{
+
+  imports = [
+    ../modules/base-service.nix
+  ];
+
+  # Performance testing temporary changes; suitable for vertical scaling with
+  # t3.xlarge (16 GB RAM, 4 vCPU, 30 GB gp2)
+  systemd.services.cardano-node.serviceConfig.MemoryMax = lib.mkForce "14G";
+
+  # Similarly, increase the max gc memory -- modify `-M` param
+  # https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/runtime_control.html
+  services.cardano-node.extraArgs = lib.mkForce [ "+RTS" "-N4" "-A10m" "-qg" "-qb" "-M10G" "-RTS" ];
+
+  systemd.services.cardano-node.serviceConfig.LimitNOFILE = "65535";
+
+  # Add host and container auto metrics and alarming
+  services.netdata = {
+    enable = true;
+    config = {
+      global = {
+        "default port" = "19999";
+        "bind to" = "*";
+        "history" = "86400";
+        "error log" = "syslog";
+        "debug log" = "syslog";
+      };
+    };
+  };
+}

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -4,7 +4,7 @@
       name = "c-a-1";
       region = "eu-central-1";
       staticRoutes = [
-        [ "c-a-2" "c-d-1" ]
+        [ "b-d-1" "c-d-1" ]
         [ "c-c-2" "c-c-1" ]
         [ "r-a-1" "r-a-2" ]
         [ "b-a-1" "b-b-1" ]
@@ -13,22 +13,10 @@
       nodeId = 1;
     }
     {
-      name = "c-a-2";
-      region = "eu-central-1";
-      staticRoutes = [
-        [ "c-d-1" "c-a-1" ]
-        [ "c-b-1" "c-d-1" ]
-        [ "c-a-1" "c-b-1" ]
-        [ "r-a-2" "r-c-1" ]
-      ];
-      org = "IOHK";
-      nodeId = 2;
-    }
-    {
       name = "c-b-1";
       region = "ap-northeast-1";
       staticRoutes = [
-        [ "c-b-2" "r-b-2" ]
+        [ "b-d-1" "r-b-2" ]
         [ "c-c-1" "c-c-2" ]
         [ "c-a-1" "c-d-1" ]
         [ "r-b-1" "r-b-2" ]
@@ -36,18 +24,6 @@
       ];
       org = "Emurgo";
       nodeId = 3;
-    }
-    {
-      name = "c-b-2";
-      region = "ap-northeast-1";
-      staticRoutes = [
-        [ "c-a-2" "c-d-1" ]
-        [ "c-b-1" "r-b-1" ]
-        [ "r-b-2" "r-b-1" ]
-        [ "b-b-1" "b-c-1" ]
-      ];
-      org = "Emurgo";
-      nodeId = 4;
     }
     {
       name = "c-c-1";
@@ -65,7 +41,7 @@
       name = "c-c-2";
       region = "ap-southeast-1";
       staticRoutes = [
-        [ "c-b-2" "c-b-1" ]
+        [ "b-b-1" "c-b-1" ]
         [ "c-c-1" "r-c-1" ]
         [ "r-c-2" "r-c-1" ]
         [ "b-c-1" "b-b-1" ]
@@ -77,8 +53,8 @@
       name = "c-d-1";
       region = "us-east-2";
       staticRoutes = [
-        [ "c-a-1" "c-a-2" ]
-        [ "c-b-1" "c-b-2" ]
+        [ "c-a-1" "b-a-1" ]
+        [ "c-b-1" "b-b-1" ]
         [ "c-c-1" "c-c-2" ]
         [ "r-d-1" "r-a-1" ]
         [ "b-d-1" "b-b-1" ]
@@ -94,7 +70,7 @@
       region = "eu-central-1";
       staticRoutes = [
         [ "c-d-1" "c-a-1" ]
-        [ "c-a-2" "c-a-1" ]
+        [ "b-c-1" "c-a-1" ]
         [ "r-a-2" "r-d-1" ]
         [ "b-a-1" "b-b-1" ]
       ];
@@ -105,7 +81,7 @@
       region = "eu-central-1";
       staticRoutes = [
         [ "c-a-1" "c-d-1" ]
-        [ "c-a-2" "c-d-1" ]
+        [ "b-b-1" "c-d-1" ]
         [ "r-d-1" "r-a-1" ]
         [ "b-a-1" "b-c-1" ]
       ];
@@ -115,8 +91,8 @@
       name = "r-d-1";
       region = "us-east-2";
       staticRoutes = [
-        [ "c-d-1" "c-a-2" ]
-        [ "c-a-1" "c-a-2" ]
+        [ "c-d-1" "b-a-1" ]
+        [ "c-a-1" "b-a-1" ]
         [ "r-a-1" "r-a-2" ]
         [ "r-b-1" "r-b-2" ]
         [ "b-d-1" "b-c-1" ]
@@ -127,7 +103,7 @@
       name = "r-b-1";
       region = "ap-northeast-1";
       staticRoutes = [
-        [ "c-b-1" "c-b-2" ]
+        [ "c-b-1" "b-b-1" ]
         [ "r-d-1" "r-a-2" ]
         [ "r-b-2" "r-c-1" ]
         [ "b-b-1" "b-a-1" ]
@@ -138,7 +114,7 @@
       name = "r-b-2";
       region = "ap-northeast-1";
       staticRoutes = [
-        [ "c-b-2" "c-b-1" ]
+        [ "b-a-1" "c-b-1" ]
         [ "r-b-1" "r-a-1" ]
         [ "r-c-2" "r-c-1" ]
         [ "b-b-1" "b-c-1" ]
@@ -554,7 +530,7 @@
       region = "eu-central-1";
       org = "IOHK";
       nodeId = 15;
-      producers = [ "b-b-1" "b-c-1" "b-d-1" "e-a-1" "e-a-2" "e-a-3" "e-a-4" "e-a-5" ];
+      producers = [ "c-a-2" "b-b-1" "b-c-1" "b-d-1" "e-a-1" "e-a-2" "e-a-3" "e-a-4" "e-a-5" ];
       staticRoutes = [
         [ "r-a-1" "r-d-1" "r-c-2" ]
         [ "r-a-2" "r-c-1" "r-b-2" ]
@@ -565,7 +541,7 @@
       region = "ap-northeast-1";
       org = "IOHK";
       nodeId = 16;
-      producers = [ "b-a-1" "b-c-1" "b-d-1" "e-b-1" "e-b-2" "e-b-3" "e-b-4" "e-b-5" ];
+      producers = [ "c-b-2" "b-a-1" "b-c-1" "b-d-1" "e-b-1" "e-b-2" "e-b-3" "e-b-4" "e-b-5" ];
       staticRoutes = [
         [ "r-b-1" "r-d-1" "r-c-1" ]
         [ "r-b-2" "r-c-2" "r-a-1" ]
@@ -576,7 +552,7 @@
       region = "ap-southeast-1";
       org = "IOHK";
       nodeId = 17;
-      producers = [ "b-a-1" "b-b-1" "b-d-1" "e-c-1" "e-c-2" "e-c-3" "e-c-4" "e-c-5" ];
+      producers = [ "c-a-2" "b-a-1" "b-b-1" "b-d-1" "e-c-1" "e-c-2" "e-c-3" "e-c-4" "e-c-5" ];
       staticRoutes = [
         [ "r-c-1" "r-d-1" "r-b-2" ]
         [ "r-c-2" "r-b-1" "r-a-2" ]
@@ -587,14 +563,29 @@
       region = "us-east-2";
       org = "IOHK";
       nodeId = 18;
-      producers = [ "b-a-1" "b-b-1" "b-c-1" "e-d-1" "e-d-2" "e-d-3" "e-d-4" "e-d-5" ];
+      producers = [ "c-b-2" "b-a-1" "b-b-1" "b-c-1" "e-d-1" "e-d-2" "e-d-3" "e-d-4" "e-d-5" ];
       staticRoutes = [
         [ "r-d-1" "r-a-2" "r-b-2" "r-c-2" ]
       ];
     }
   ];
 
-  coreNodes = [ ];
+  coreNodes = [
+    {
+      name = "c-a-2";
+      region = "eu-central-1";
+      producers = ["b-a-1" "c-b-2" "b-d-1" "e-a-1" "e-a-2" "e-a-3" "e-a-4" "e-a-5" "e-c-2" "e-b-2" "e-d-2"];
+      org = "IOHK";
+      nodeId = 2;
+    }
+    {
+      name = "c-b-2";
+      region = "ap-northeast-1";
+      producers = ["b-b-1" "c-a-2" "b-c-1" "e-b-1" "e-b-2" "e-b-3" "e-b-4" "e-b-5" "e-a-4" "e-c-4" "e-d-4"];
+      org = "Emurgo";
+      nodeId = 4;
+    }
+   ];
 
   relayNodes = [
 
@@ -605,35 +596,35 @@
       region = "eu-central-1";
       org = "IOHK";
       nodeId = 8;
-      producers = [ "b-a-1" "e-a-2" "e-a-3" "e-a-4" "e-a-5" "e-b-1" "e-c-1" "e-d-1" ];
+      producers = [ "b-a-1" "c-a-2" "e-a-2" "e-a-3" "e-a-4" "e-a-5" "e-b-1" "e-c-1" "e-d-1" ];
     }
     {
       name = "e-a-2";
       region = "eu-central-1";
       org = "IOHK";
       nodeId = 19;
-      producers = [ "b-a-1" "e-a-1" "e-a-3" "e-a-4" "e-a-5" "e-b-2" "e-c-2" "e-d-2" ];
+      producers = [ "b-a-1" "c-a-2" "e-a-1" "e-a-3" "e-a-4" "e-a-5" "e-b-2" "e-c-2" "e-d-2" ];
     }
     {
       name = "e-a-3";
       region = "eu-central-1";
       org = "IOHK";
       nodeId = 20;
-      producers = [ "b-a-1" "e-a-1" "e-a-2" "e-a-4" "e-a-5" "e-b-3" "e-c-3" "e-d-3" ];
+      producers = [ "b-a-1" "c-a-2" "e-a-1" "e-a-2" "e-a-4" "e-a-5" "e-b-3" "e-c-3" "e-d-3" ];
     }
     {
       name = "e-a-4";
       region = "eu-central-1";
       org = "IOHK";
       nodeId = 21;
-      producers = [ "b-a-1" "e-a-1" "e-a-2" "e-a-3" "e-a-5" "e-b-4" "e-c-4" "e-d-4" ];
+      producers = [ "b-a-1" "c-a-2" "e-a-1" "e-a-2" "e-a-3" "e-a-5" "e-b-4" "e-c-4" "e-d-4" ];
     }
     {
       name = "e-a-5";
       region = "eu-central-1";
       org = "IOHK";
       nodeId = 22;
-      producers = [ "b-a-1" "e-a-1" "e-a-2" "e-a-3" "e-a-4" "e-b-5" "e-c-5" "e-d-5" ];
+      producers = [ "b-a-1" "c-a-2" "e-a-1" "e-a-2" "e-a-3" "e-a-4" "e-b-5" "e-c-5" "e-d-5" ];
     }
 
     # e-a-6 - 10 edge nodes
@@ -795,35 +786,35 @@
       region = "ap-northeast-1";
       org = "IOHK";
       nodeId = 9;
-      producers = [ "b-b-1" "e-b-2" "e-b-3" "e-b-4" "e-b-5" "e-a-1" "e-c-1" "e-d-1" ];
+      producers = [ "b-b-1" "c-b-2" "e-b-2" "e-b-3" "e-b-4" "e-b-5" "e-a-1" "e-c-1" "e-d-1" ];
     }
     {
       name = "e-b-2";
       region = "ap-northeast-1";
       org = "IOHK";
       nodeId = 23;
-      producers = [ "b-b-1" "e-b-1" "e-b-3" "e-b-4" "e-b-5" "e-a-2" "e-c-2" "e-d-2" ];
+      producers = [ "b-b-1" "c-b-2" "e-b-1" "e-b-3" "e-b-4" "e-b-5" "e-a-2" "e-c-2" "e-d-2" ];
     }
     {
       name = "e-b-3";
       region = "ap-northeast-1";
       org = "IOHK";
       nodeId = 24;
-      producers = [ "b-b-1" "e-b-1" "e-b-2" "e-b-4" "e-b-5" "e-a-3" "e-c-3" "e-d-3" ];
+      producers = [ "b-b-1" "c-b-2" "e-b-1" "e-b-2" "e-b-4" "e-b-5" "e-a-3" "e-c-3" "e-d-3" ];
     }
     {
       name = "e-b-4";
       region = "ap-northeast-1";
       org = "IOHK";
       nodeId = 25;
-      producers = [ "b-b-1" "e-b-1" "e-b-2" "e-b-3" "e-b-5" "e-a-4" "e-c-4" "e-d-4" ];
+      producers = [ "b-b-1" "c-b-2" "e-b-1" "e-b-2" "e-b-3" "e-b-5" "e-a-4" "e-c-4" "e-d-4" ];
     }
     {
       name = "e-b-5";
       region = "ap-northeast-1";
       org = "IOHK";
       nodeId = 26;
-      producers = [ "b-b-1" "e-b-1" "e-b-2" "e-b-3" "e-b-4" "e-a-5" "e-c-5" "e-d-5" ];
+      producers = [ "b-b-1" "c-b-2" "e-b-1" "e-b-2" "e-b-3" "e-b-4" "e-a-5" "e-c-5" "e-d-5" ];
     }
 
     # e-b-6 - 10 edge nodes

--- a/topologies/staging-shelley.nix
+++ b/topologies/staging-shelley.nix
@@ -171,7 +171,6 @@
     }
   ];
 
-
   byronProxies = [
     {
       name = "p-a-1";
@@ -253,6 +252,14 @@
       org = "IOHK";
       nodeId = 10;
       producers = [ "p-c-1" "c-c-2" "e-a-1" "e-b-1"  ];
+    }
+  ];
+
+  testNodes = [
+    {
+      name = "l-a-1";
+      region = "eu-central-1";
+      org = "IOHK";
     }
   ];
 }

--- a/topologies/staging.nix
+++ b/topologies/staging.nix
@@ -259,6 +259,7 @@
   ];
 
   relayNodes = [
+    # Group 1 (original group)
     {
       name = "e-a-1";
       region = "eu-central-1";
@@ -280,5 +281,142 @@
       nodeId = 10;
       producers = ["p-c-1" "c-c-2" "e-a-1" "e-b-1"];
     }
+
+    # Likely will want to update the producers of all these nodes once created
+    # Group 2
+
+    {
+      name = "e-a-2";
+      region = "eu-central-1";
+      org = "IOHK";
+      nodeId = 21;
+      producers = ["p-a-1" "c-a-2" "e-b-1" "e-c-1"];
+    }
+    {
+      name = "e-b-2";
+      region = "ap-northeast-1";
+      org = "IOHK";
+      nodeId = 22;
+      producers = ["p-b-1" "c-b-2" "e-a-1" "e-c-1"];
+    }
+    {
+      name = "e-c-2";
+      region = "ap-southeast-1";
+      org = "IOHK";
+      nodeId = 23;
+      producers = ["p-c-1" "c-c-2" "e-a-1" "e-b-1"];
+    }
+
+    {
+      name = "e-a-3";
+      region = "eu-central-1";
+      org = "IOHK";
+      nodeId = 24;
+      producers = ["p-a-1" "c-a-2" "e-b-1" "e-c-1"];
+    }
+    {
+      name = "e-b-3";
+      region = "ap-northeast-1";
+      org = "IOHK";
+      nodeId = 25;
+      producers = ["p-b-1" "c-b-2" "e-a-1" "e-c-1"];
+    }
+    {
+      name = "e-c-3";
+      region = "ap-southeast-1";
+      org = "IOHK";
+      nodeId = 26;
+      producers = ["p-c-1" "c-c-2" "e-a-1" "e-b-1"];
+    }
+
+    {
+      name = "e-a-4";
+      region = "eu-central-1";
+      org = "IOHK";
+      nodeId = 27;
+      producers = ["p-a-1" "c-a-2" "e-b-1" "e-c-1"];
+    }
+    {
+      name = "e-b-4";
+      region = "ap-northeast-1";
+      org = "IOHK";
+      nodeId = 28;
+      producers = ["p-b-1" "c-b-2" "e-a-1" "e-c-1"];
+    }
+    {
+      name = "e-c-4";
+      region = "ap-southeast-1";
+      org = "IOHK";
+      nodeId = 29;
+      producers = ["p-c-1" "c-c-2" "e-a-1" "e-b-1"];
+    }
+
+    # Group 3 -- not deployed yet
+
+    #{
+    #  name = "e-a-5";
+    #  region = "eu-central-1";
+    #  org = "IOHK";
+    #  nodeId = 30;
+    #  producers = ["p-a-1" "c-a-2" "e-b-1" "e-c-1"];
+    #}
+    #{
+    #  name = "e-b-5";
+    #  region = "ap-northeast-1";
+    #  org = "IOHK";
+    #  nodeId = 31;
+    #  producers = ["p-b-1" "c-b-2" "e-a-1" "e-c-1"];
+    #}
+    #{
+    #  name = "e-c-5";
+    #  region = "ap-southeast-1";
+    #  org = "IOHK";
+    #  nodeId = 32;
+    #  producers = ["p-c-1" "c-c-2" "e-a-1" "e-b-1"];
+    #}
+
+    #{
+    #  name = "e-a-6";
+    #  region = "eu-central-1";
+    #  org = "IOHK";
+    #  nodeId = 33;
+    #  producers = ["p-a-1" "c-a-2" "e-b-1" "e-c-1"];
+    #}
+    #{
+    #  name = "e-b-6";
+    #  region = "ap-northeast-1";
+    #  org = "IOHK";
+    #  nodeId = 34;
+    #  producers = ["p-b-1" "c-b-2" "e-a-1" "e-c-1"];
+    #}
+    #{
+    #  name = "e-c-6";
+    #  region = "ap-southeast-1";
+    #  org = "IOHK";
+    #  nodeId = 35;
+    #  producers = ["p-c-1" "c-c-2" "e-a-1" "e-b-1"];
+    #}
+
+    #{
+    #  name = "e-a-7";
+    #  region = "eu-central-1";
+    #  org = "IOHK";
+    #  nodeId = 36;
+    #  producers = ["p-a-1" "c-a-2" "e-b-1" "e-c-1"];
+    #}
+    #{
+    #  name = "e-b-7";
+    #  region = "ap-northeast-1";
+    #  org = "IOHK";
+    #  nodeId = 37;
+    #  producers = ["p-b-1" "c-b-2" "e-a-1" "e-c-1"];
+    #}
+    #{
+    #  name = "e-c-7";
+    #  region = "ap-southeast-1";
+    #  org = "IOHK";
+    #  nodeId = 38;
+    #  producers = ["p-c-1" "c-c-2" "e-a-1" "e-b-1"];
+    #}
   ];
 }


### PR DESCRIPTION
* Adds faucet and faucet hostname cluster flags
* Adds high capacity monitoring cluster flag
* Adds high load relay cluster flag
* Adds optional testNodes topology type for prometheus monitored clients
* Adds Grafana byron-reboot edge monitoring dashboard
* Adds higher prometheus monitoring capacity
* Bumps node to 1.10.0
* Deploys updated devOps ssh keys
* Adds explorer server aliases