### PR TITLE
Avoid repeated evaluation of ./nix and cardanoNodePkgs

### DIFF
--- a/clusters/cardano.nix
+++ b/clusters/cardano.nix
@@ -94,7 +94,6 @@ let
       imports = [
         xlarge
         cardano-ops.roles.explorer
-        cardano-ops.modules.base-service
       ]
       # TODO: remove module when the new explorer is available
       ++ lib.optional (globals.withLegacyExplorer) cardano-ops.roles.explorer-legacy;

--- a/clusters/cardano.nix
+++ b/clusters/cardano.nix
@@ -1,4 +1,5 @@
-{ targetEnv
+{ pkgs
+, targetEnv
 , medium               # Standard relay
 , xlarge               # Standard explorer
 , t3-xlarge            # High load relay
@@ -7,13 +8,12 @@
 , t3-2xlarge-monitor   # High capacity monitor
 , ...
 }:
-with (import ../nix {});
+with pkgs;
 let
 
   inherit (globals) topology byronProxyPort;
   inherit (topology) legacyCoreNodes legacyRelayNodes byronProxies coreNodes relayNodes;
   inherit (lib) recursiveUpdate mapAttrs listToAttrs imap1 concatLists;
-  inherit (iohk-ops-lib) roles modules;
 
   # for now, keys need to be generated for each core nodes with:
   # for i in {1..2}; do cardano-cli --byron-legacy keygen --secret ./keys/$i.sk --no-password; done
@@ -32,8 +32,8 @@ let
       deployment.ec2.region = def.region or "eu-central-1";
       imports = [
         (if globals.withHighCapacityMonitoring then t3-2xlarge-monitor else xlarge-monitor)
-        roles.monitor
-        ../modules/monitoring-cardano.nix
+        iohk-ops-lib.roles.monitor
+        cardano-ops.modules.monitoring-cardano
       ];
       node = {
         roles.isMonitor = true;
@@ -93,11 +93,11 @@ let
       };
       imports = [
         xlarge
-        ../roles/explorer.nix
-        ../modules/base-service.nix
+        cardano-ops.roles.explorer
+        cardano-ops.modules.base-service
       ]
       # TODO: remove module when the new explorer is available
-      ++ lib.optional (globals.withLegacyExplorer) ../roles/explorer-legacy.nix;
+      ++ lib.optional (globals.withLegacyExplorer) cardano-ops.roles.explorer-legacy;
 
       services.monitoring-exporters.extraPrometheusExportersPorts =
         [ globals.cardanoNodePrometheusExporterPort ];
@@ -118,7 +118,7 @@ let
       };
       imports = [
         medium
-        ../roles/faucet.nix
+        cardano-ops.roles.faucet
       ];
       node = {
         roles.isFaucet = true;
@@ -139,9 +139,9 @@ let
       };
       deployment.ec2.region = def.region;
       imports = [ medium ] ++ (if (globals.environmentConfig.consensusProtocol == "TPraos") then [
-        ../roles/shelley-core.nix
+        cardano-ops.roles.shelley-core
       ] else [
-        ../roles/core.nix
+        cardano-ops.roles.core
       ]);
       services.cardano-node = {
         inherit (def) producers;
@@ -162,9 +162,9 @@ let
       };
       deployment.ec2.region = def.region;
       imports = if globals.withHighLoadRelays then [
-        t3-xlarge ../roles/relay-high-load.nix
+        t3-xlarge cardano-ops.roles.relay-high-load
       ] else [
-        medium ../roles/relay.nix
+        medium cardano-ops.roles.relay
       ];
     } def;
   };
@@ -182,7 +182,7 @@ let
       deployment.ec2.region = def.region;
       imports = [
         medium
-        ../roles/byron-proxy.nix
+        cardano-ops.roles.byron-proxy
       ];
       services.cardano-node-legacy.staticRoutes = def.staticRoutes or [];
       services.cardano-node-legacy.dynamicSubscribe = def.dynamicSubscribe or [];
@@ -200,10 +200,10 @@ let
         inherit (def) org nodeId;
       };
       deployment.ec2.region = def.region;
-      imports = [ medium ../roles/legacy-core.nix ];
+      imports = [ medium cardano-ops.roles.legacy-core ];
       # Temporary for legacy migration:
-      #imports = [ medium ../roles/legacy-core.nix;
-      # ../roles/sync-nonlegacy-chain-state.nix ];
+      #imports = [ medium cardano-ops.roles.legacy-core
+      # cardano-ops.roles.sync-nonlegacy-chain-state ];
       services.cardano-node-legacy.staticRoutes = def.staticRoutes;
     } def;
   };
@@ -216,7 +216,7 @@ let
         inherit (def) org;
       };
       deployment.ec2.region = def.region;
-      imports = [ medium ../roles/legacy-relay.nix ];
+      imports = [ medium cardano-ops.roles.legacy-relay ];
       services.cardano-node-legacy.staticRoutes = def.staticRoutes or [];
       services.cardano-node-legacy.dynamicSubscribe = def.dynamicSubscribe or [];
     } def;
@@ -230,7 +230,7 @@ let
         inherit (def) org;
       };
       deployment.ec2.region = def.region;
-      imports = [ m5ad-xlarge ../roles/load-client.nix ];
+      imports = [ m5ad-xlarge cardano-ops.roles.load-client ];
     } def;
   };
 
@@ -239,8 +239,7 @@ let
       recursiveUpdate {
         imports = args.imports ++ (def.imports or []);
         deployment.targetEnv = targetEnv;
-        nixpkgs.overlays = pkgs.cardano-ops-overlays;
-        _module.args.cardanoNodePkgs = lib.mkDefault cardanoNodePkgs;
+        nixpkgs.overlays = pkgs.cardano-ops.overlays;
       } args)
       (builtins.removeAttrs def [
         "imports"

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,7 @@
 }@args: with import ./nix args; {
 
   shell = let
-    cardanoSL = import sourcePaths.cardano-sl {};
-    genesisFile = (import sourcePaths.iohk-nix {}).cardanoLib.environments.${globals.environmentName}.genesisFile or "please/set/globals.environmentName";
+    genesisFile = iohkNix.cardanoLib.environments.${globals.environmentName}.genesisFile or "please/set/globals.environmentName";
 
     mkDevGenesis = writeShellScriptBin "make-dev-genesis" (builtins.replaceStrings
       [ "\${RUNNER}"
@@ -51,7 +50,7 @@
      '';
   in  mkShell {
     buildInputs = [ niv nixops nix cardano-cli telnet dnsutils mkDevGenesis nix-diff migrate-keys create-shelley-genesis-and-keys ] ++
-                  (with cardanoSL.nix-tools.exes; [ cardano-sl-auxx cardano-sl-tools ]);
+                  (with cardano-sl-pkgs.nix-tools.exes; [ cardano-sl-auxx cardano-sl-tools ]);
     NIX_PATH = "nixpkgs=${path}";
     NIXOPS_DEPLOYMENT = "${globals.deploymentName}";
     passthru = {

--- a/deployments/cardano-aws.nix
+++ b/deployments/cardano-aws.nix
@@ -10,6 +10,7 @@ let
   inherit (iohk-ops-lib.physical) aws;
 
   cluster = import ../clusters/cardano.nix {
+    inherit pkgs;
     inherit (aws) targetEnv;
     medium = aws.t3a-medium;                     # Standard relay
     xlarge = aws.t3a-xlarge;                     # Standard explorer

--- a/deployments/cardano-libvirtd.nix
+++ b/deployments/cardano-libvirtd.nix
@@ -1,5 +1,14 @@
-import ../clusters/cardano.nix (with (import ../nix {}).iohk-ops-lib.physical.libvirtd; {
-  inherit targetEnv medium;
+with import ../nix {};
+
+import ../clusters/cardano.nix (with iohk-ops-lib.physical.libvirtd; {
+  inherit targetEnv medium pkgs;
   xlarge = large;
   xlarge-monitor = large;
-})
+  m5ad-xlarge = large;
+  t3-xlarge = large;
+  t3-2xlarge-monitor = large;
+}) // lib.optionalAttrs (builtins.getEnv "BUILD_ONLY" == "true") {
+  defaults = {
+    users.users.root.openssh.authorizedKeys.keys = lib.mkForce [""];
+  };
+}

--- a/modules/base-legacy-service.nix
+++ b/modules/base-legacy-service.nix
@@ -1,5 +1,5 @@
-{ pkgs, name, nodes, config, options, resources, ... }:
-with (import ../nix {}); with lib;
+pkgs: { name, nodes, config, options, resources, ... }:
+with pkgs; with lib;
 let
   inherit (iohkNix.cardanoLib) cardanoConfig;
   cfg = config.services.cardano-node-legacy;
@@ -24,7 +24,7 @@ let
 in {
 
   imports = [
-    ./common-cardano-legacy.nix
+    cardano-ops.modules.common-cardano-legacy
   ];
 
   options = {

--- a/modules/base-service.nix
+++ b/modules/base-service.nix
@@ -1,7 +1,6 @@
-{ pkgs, lib, options, config, name, nodes, resources,  ... }:
-with (import ../nix {}); with lib;
+pkgs: { options, config, name, nodes, resources,  ... }:
+with pkgs; with lib;
 let
-  iohkNix = import sourcePaths.iohk-nix {};
 
   nodeId = config.node.nodeId;
   cfg = config.services.cardano-node;
@@ -29,13 +28,13 @@ let
     valency = 1;
   }) cfg.producers;
 
-  topology =  builtins.toFile "topology.yaml" (builtins.toJSON {
+  topology = builtins.toFile "topology.yaml" (builtins.toJSON {
     Producers = producers;
   });
 in
 {
   imports = [
-    ./common.nix
+    cardano-ops.modules.common
     (sourcePaths.cardano-node + "/nix/nixos")
   ];
 
@@ -86,7 +85,9 @@ in
           ]
         ];
       };
-    };
+    } // (optionalAttrs (options.services.cardano-node ? cardanoNodePkgs) {
+      inherit cardanoNodePkgs;
+    });
     systemd.services.cardano-node.serviceConfig.MemoryMax = "3.5G";
     # TODO remove next two line for next release cardano-node 1.7 release:
     systemd.services.cardano-node.scriptArgs = toString cfg.nodeId;

--- a/modules/cardano-explorer-python.nix
+++ b/modules/cardano-explorer-python.nix
@@ -1,9 +1,8 @@
-{ config, lib, ... }:
-with import ../nix {};
+pkgs: { config,  ... }:
+with pkgs;
 
 let
   inherit (lib) mkForce mkIf mkEnableOption mkOption types;
-  cardano-sl-pkgs = import sourcePaths.cardano-sl { gitrev = sourcePaths.cardano-sl.rev; };
   explorerPythonAPI = cardano-sl-pkgs.explorerPythonAPI;
   cfg = config.services.explorer-python-api;
 in {

--- a/modules/cardano-postgres.nix
+++ b/modules/cardano-postgres.nix
@@ -1,5 +1,5 @@
-{ config, pkgs, lib, ... }:
-with import ../nix {};
+pkgs: { config, ... }:
+with pkgs;
 
 let
   inherit (lib) mkForce mkIf mkEnableOption mkOption types;

--- a/modules/common-cardano-legacy.nix
+++ b/modules/common-cardano-legacy.nix
@@ -1,5 +1,5 @@
-{ pkgs, name, nodes, config, options, resources, ... }:
-with (import ../nix {}); with lib;
+pkgs: { name, nodes, config, options, resources, ... }:
+with pkgs; with lib;
 let
   cfg = config.services.cardano-node-legacy;
   port = globals.cardanoNodeLegacyPort;
@@ -35,7 +35,7 @@ let
 in {
 
   imports = [
-    ./common.nix
+    cardano-ops.modules.common
   ];
 
   options = {

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -12,10 +12,6 @@ in {
 
   options = {
     node = {
-      org = lib.mkOption {
-        type = lib.types.enum [ "IOHK" "Emurgo" "CF" ];
-        default = "IOHK";
-      };
       coreIndex = lib.mkOption {
         type = lib.types.int;
       };

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -1,5 +1,5 @@
-with (import ../nix {});
-{ ... }:
+pkgs:
+with pkgs;
 let
   boolOption = lib.mkOption {
     type = lib.types.bool;

--- a/modules/load-client.nix
+++ b/modules/load-client.nix
@@ -1,5 +1,5 @@
-{ pkgs, config, lib, nodes, name, ... }:
-with (import ../nix {}); with lib;
+pkgs: { config, options, nodes, name, ... }:
+with pkgs; with lib;
 let
   cfg = config.services.cardano-node;
   nodePort = globals.cardanoNodePort;
@@ -8,7 +8,7 @@ let
 in
 {
   imports = [
-    ./common.nix
+    cardano-ops.modules.common
     (sourcePaths.cardano-node + "/nix/nixos")
   ];
 
@@ -43,7 +43,9 @@ in
       edgeHost = iohkNix.cardanoLib.environments."${globals.environmentName}".relaysNew;
       edgeNodes = [];
     };
-  };
+  } // (optionalAttrs (options.services.cardano-node ? cardanoNodePkgs) {
+      inherit cardanoNodePkgs;
+  });
   systemd.services.cardano-node.serviceConfig.MemoryMax = "3.5G";
   # TODO remove next two line for next release cardano-node 1.7 release:
   systemd.services.cardano-node.preStart = ''

--- a/modules/nginx-monitoring-proxy.nix
+++ b/modules/nginx-monitoring-proxy.nix
@@ -1,7 +1,7 @@
-{ config, ... }:
+pkgs: { config, ... }:
 let
   cfg = config.services.nginx-monitoring-proxy;
-in with import ../nix {}; {
+in with pkgs; {
   options = {
     services.nginx-monitoring-proxy = {
       proxyName = lib.mkOption {

--- a/nix/cardano.nix
+++ b/nix/cardano.nix
@@ -6,7 +6,7 @@ let
 in rec {
   cardanoNodePkgs = import (self.sourcePaths.cardano-node + "/nix") {};
   inherit (cardanoNodePkgs.cardanoNodeHaskellPackages.cardano-cli.components.exes) cardano-cli;
-
+  inherit cardano-sl-pkgs;
   cardano-node-legacy = cardano-sl-pkgs.nix-tools.cexes.cardano-sl-node.cardano-node-simple;
   cardano-node-legacy-config = cardano-sl-pkgs.cardanoConfig; # FIXME: use iohk-nix
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -49,10 +49,13 @@ let
     })];
 
   # merge upstream sources with our own:
-  upstream-overlay = _: super: {
+  upstream-overlay = self: super: {
       inherit iohkNix;
-
-    cardano-ops-overlays = overlays;
+    cardano-ops = {
+      inherit overlays;
+      modules = self.importWithPkgs ../modules;
+      roles = self.importWithPkgs ../roles;
+    };
     sourcePaths = (super.sourcePaths or {}) // sourcePaths;
   };
 

--- a/physical/aws/security-groups/allow-legacy-public.nix
+++ b/physical/aws/security-groups/allow-legacy-public.nix
@@ -1,3 +1,4 @@
-with import ../../../nix {};
+{ pkgs, ... }@args:
+with pkgs;
 iohk-ops-lib.physical.aws.security-groups.allow-all-to-tcp-port
-  "cardano-legacy" globals.cardanoNodeLegacyPort
+  "cardano-legacy" globals.cardanoNodeLegacyPort args

--- a/physical/aws/security-groups/allow-public.nix
+++ b/physical/aws/security-groups/allow-public.nix
@@ -1,3 +1,4 @@
-with import ../../../nix {};
+{ pkgs, ... }@args:
+with pkgs;
 iohk-ops-lib.physical.aws.security-groups.allow-all-to-tcp-port
-  "cardano" globals.cardanoNodePort
+  "cardano" globals.cardanoNodePort args

--- a/release.nix
+++ b/release.nix
@@ -26,7 +26,7 @@
 , pkgs ? import ./nix {}
 }:
 
-with import ((import pkgs.sourcePaths.iohk-nix) {}).release-lib {
+with import pkgs.iohkNix.release-lib {
   inherit pkgs;
 
   inherit supportedSystems supportedCrossSystems scrubJobs projectArgs;

--- a/roles/byron-proxy.nix
+++ b/roles/byron-proxy.nix
@@ -1,13 +1,13 @@
+pkgs:
 { name
 , config
 , nodes
 , resources
 , ...
 }:
-with import ../nix {};
+with pkgs;
 let
   cfg = config.services.byron-proxy;
-  iohkNix = import sourcePaths.iohk-nix {};
   inherit (iohkNix) cardanoLib;
   legacyCardanoCfg = config.services.cardano-node-legacy;
   hostAddr = getListenIp nodes.${name};
@@ -28,7 +28,7 @@ let
 in {
 
   imports = [
-    ../modules/common-cardano-legacy.nix
+    cardano-ops.modules.common-cardano-legacy
     (sourcePaths.cardano-byron-proxy + "/nix/nixos")
   ];
 

--- a/roles/core.nix
+++ b/roles/core.nix
@@ -1,6 +1,6 @@
 
-{config, name, lib, ...}:
-with import ../nix {};
+pkgs: {config, name, ...}:
+with pkgs;
 let
   nodeId = config.node.nodeId;
   signingKey = ../keys/delegate-keys + ".${leftPad nodeId 3}.key";
@@ -9,7 +9,7 @@ let
 in {
 
   imports = [
-    ../modules/base-service.nix
+    cardano-ops.modules.base-service
   ];
 
   services.cardano-node = {

--- a/roles/explorer-legacy.nix
+++ b/roles/explorer-legacy.nix
@@ -1,16 +1,14 @@
-{ config, lib, ... }:
-with import ../nix {};
+pkgs: { config, ... }:
+with pkgs;
 
 let
   inherit (lib) mkForce;
-  cardano-sl-pkgs = import sourcePaths.cardano-sl { gitrev = sourcePaths.cardano-sl.rev; };
   explorerFrontend = (import sourcePaths.cardano-sl-explorer { gitrev = sourcePaths.cardano-sl-explorer.rev; }).explorerFrontend;
   explorerLegacy = cardano-sl-pkgs.nix-tools.cexes.cardano-sl-explorer.cardano-explorer;
 in {
   imports = [
-    ./legacy-relay.nix
-    ../modules/common.nix
-    ../modules/cardano-explorer-python.nix
+    cardano-ops.roles.legacy-relay
+    cardano-ops.modules.cardano-explorer-python
   ];
 
   # goaccess package assists in analysis of live nginx logs, ex: during DoS

--- a/roles/explorer.nix
+++ b/roles/explorer.nix
@@ -1,12 +1,10 @@
-{ config, lib, name, nodes, ... }:
-with import ../nix {};
+pkgs: { config, options, name, nodes, ... }:
+with pkgs;
 
 let
   nodeCfg = config.services.cardano-node;
-  iohkNix = import sourcePaths.iohk-nix {};
-  cardano-sl = import sourcePaths.cardano-sl { gitrev = sourcePaths.cardano-sl.rev; };
   cardano-explorer-app = import sourcePaths.cardano-explorer-app {};
-  explorerFrontend = cardano-sl.explorerFrontend;
+  explorerFrontend = cardano-sl-pkgs.explorerFrontend;
   postgresql12 = (import sourcePaths.nixpkgs-postgresql12 {}).postgresql_12;
   nodeId = config.node.nodeId;
   hostAddr = getListenIp nodes.${name};
@@ -17,8 +15,8 @@ in {
     (sourcePaths.cardano-graphql + "/nix/nixos")
     (sourcePaths.cardano-rest + "/nix/nixos")
     (sourcePaths.cardano-db-sync + "/nix/nixos")
-    ../modules/common.nix
-    ../modules/cardano-postgres.nix
+    cardano-ops.modules.common
+    cardano-ops.modules.cardano-postgres
   ];
 
   environment.systemPackages = with pkgs; [
@@ -63,7 +61,9 @@ in {
     nodeConfig = globals.environmentConfig.nodeConfig // {
       hasPrometheus = [ hostAddr globals.cardanoNodePrometheusExporterPort ];
     };
-  };
+  } // (lib.optionalAttrs (options.services.cardano-node ? cardanoNodePkgs) {
+      inherit cardanoNodePkgs;
+  });
   services.cardano-db-sync = {
     enable = true;
     cluster = globals.environmentName;

--- a/roles/explorer.nix
+++ b/roles/explorer.nix
@@ -15,7 +15,7 @@ in {
     (sourcePaths.cardano-graphql + "/nix/nixos")
     (sourcePaths.cardano-rest + "/nix/nixos")
     (sourcePaths.cardano-db-sync + "/nix/nixos")
-    cardano-ops.modules.common
+    cardano-ops.modules.base-service
     cardano-ops.modules.cardano-postgres
   ];
 

--- a/roles/faucet.nix
+++ b/roles/faucet.nix
@@ -1,5 +1,5 @@
-{ name, config, nodes, resources, ... }:
-with import ../nix {};
+pkgs: { name, config, nodes, resources, ... }:
+with pkgs;
 let
   faucetPkgs = (import (sourcePaths.cardano-faucet + "/nix") {}).pkgs;
   hostAddr = getListenIp nodes.${name};
@@ -8,7 +8,7 @@ let
 in {
 
   imports = [
-    ../modules/common.nix
+    cardano-ops.modules.common
 
     # Cardano faucet needs to pair a compatible version of wallet with node
     # The following service import will do this:

--- a/roles/legacy-core.nix
+++ b/roles/legacy-core.nix
@@ -1,11 +1,11 @@
-{ resources, config, ... }:
+pkgs: { resources, config, ... }:
 let
   assetLockFile = if (builtins.pathExists ../static/asset-locked-addresses.txt) then ../static/asset-locked-addresses.txt else null;
 
 in {
 
   imports = [
-    ../modules/base-legacy-service.nix
+    pkgs.cardano-ops.modules.base-legacy-service
   ];
 
   services.cardano-node-legacy.nodeType = "core";

--- a/roles/legacy-relay.nix
+++ b/roles/legacy-relay.nix
@@ -1,8 +1,8 @@
-{ options, config, nodes, resources,  ... }:
+pkgs: { options, config, nodes, resources,  ... }:
 {
 
   imports = [
-    ../modules/base-legacy-service.nix
+    pkgs.cardano-ops.modules.base-legacy-service
   ];
 
   services.cardano-node-legacy.nodeType = "relay";

--- a/roles/load-client.nix
+++ b/roles/load-client.nix
@@ -1,7 +1,7 @@
-{ config, pkgs, ... }:
+pkgs: { config, ... }:
 {
   imports = [
-    ../modules/load-client.nix
+    pkgs.cardano-ops.modules.load-client
   ];
 
   systemd.services.cardano-node.after = [ "ephemeral.service" ];

--- a/roles/relay-high-load.nix
+++ b/roles/relay-high-load.nix
@@ -1,8 +1,8 @@
-{ lib, config, ... }:
+pkgs: with pkgs; with lib;
 {
 
   imports = [
-    ../modules/base-service.nix
+    cardano-ops.modules.base-service
   ];
 
   # Performance testing temporary changes; suitable for vertical scaling with

--- a/roles/relay.nix
+++ b/roles/relay.nix
@@ -1,8 +1,8 @@
 
-{
+pkgs: {
 
   imports = [
-    ../modules/base-service.nix
+    pkgs.cardano-ops.modules.base-service
   ];
 
 }

--- a/roles/shelley-core.nix
+++ b/roles/shelley-core.nix
@@ -1,6 +1,6 @@
 
-{config, name, lib, ...}:
-with import ../nix {};
+pkgs: {config, name, ...}:
+with pkgs;
 let
   nodeId = toString config.node.nodeId;
   vrfKey = ../keys/node-keys/node-vrf + "${nodeId}.skey";
@@ -9,7 +9,7 @@ let
 in {
 
   imports = [
-    ../modules/base-service.nix
+    cardano-ops.modules.base-service
   ];
 
   services.cardano-node = {

--- a/roles/sync-nonlegacy-chain-state.nix
+++ b/roles/sync-nonlegacy-chain-state.nix
@@ -3,10 +3,10 @@
 # to coreNode.  The relay allows a sync to the tip of the
 # nonlegacy chain state without having to stop the legacy core
 # function during the sync
-{ pkgs, ... }:
+pkgs:
 {
   imports = [
-    ./relay.nix
+    pkgs.cardano-ops.roles.relay
   ];
 
   node.roles.isCardanoRelay = true;


### PR DESCRIPTION
Significantly improve nixops eval time for cluster with lots of (new) nodes.