### PR TITLE
Update ff-peers.nix

### DIFF
--- a/topologies/ff-peers.nix
+++ b/topologies/ff-peers.nix
@@ -608,4 +608,10 @@
     port = 3002;
     valency = 1;
   }
+  {
+    operator = "SWAG-ADARelay";
+    addr = "18.221.248.208";
+    port = 3001;
+    valency = 1;
+  }
 ]


### PR DESCRIPTION
Requesting SWAG-ADA Relay is added to the ff-peers repository.
 {
    operator = "SWAG-ADA Relay";
    addr = "18.221.248.208";
    port = 3001;
  }