### PR TITLE
CAD-1331:  fix shell entry

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -32,7 +32,7 @@ let
         pk=$(cardano-cli signing-key-public --real-pbft --secret $signing_key | fgrep 'public key (base64):' | cut -d: -f2 | xargs echo -n)
         delegate_cert=keys/delegation-cert.00$i.json
         echo "generating delegation certificate for $pk in $delegate_cert"
-        ${jq}/bin/jq ".heavyDelegation | .[] | select(.delegatePk == \"$pk\")" < ${genesisFile} > $delegate_cert
+        ${jq}/bin/jq ".heavyDelegation | .[] | select(.delegatePk == \"$pk\")" < ${toString genesisFile} > $delegate_cert
       done
     '';
   create-shelley-genesis-and-keys =


### PR DESCRIPTION
This fixes a problem, where entering `nix-shell` might cause:
```
error: while evaluating the attribute 'buildInputs' of the derivation 'nix-shell' at /nix/store/kf3adfr28xj77rmqbzy98qil86380zgv-nixpkgs-src/pkgs/build-support/mkshell/default.nix:28:3:
while evaluating the attribute 'text' of the derivation 'migrate-keys' at /nix/store/kf3adfr28xj77rmqbzy98qil86380zgv-nixpkgs-src/pkgs/build-support/trivial-builders.nix:7:14:
getting attributes of path '/home/dev/bench-dist-0/keys/genesis.json': No such file or directory
```