### PR TITLE
Use  fully qualified explorerHostName,

### DIFF
--- a/globals-defaults.nix
+++ b/globals-defaults.nix
@@ -22,7 +22,7 @@ in {
   domain = "${pkgs.globals.deploymentName}.${pkgs.globals.dnsZone}";
   relaysNew = pkgs.globals.environmentConfig.relaysNew or "relays-new.${pkgs.globals.domain}";
 
-  explorerHostName = "explorer";
+  explorerHostName = "explorer.${pkgs.globals.domain}";
   explorerForceSSL = true;
   explorerAliases = [];
 

--- a/globals-mainnet.nix
+++ b/globals-mainnet.nix
@@ -6,9 +6,9 @@ pkgs: {
 
   domain = "cardano-mainnet.iohk.io";
 
-  explorerHostName = "explorer";
+  explorerHostName = "explorer.cardano.org";
   explorerForceSSL = true;
-  explorerAliases = [ "explorer.mainnet.cardano.org" "explorer.cardano.org" ];
+  explorerAliases = [ "explorer.mainnet.cardano.org" "explorer.${pkgs.globals.domain}" ];
 
   withCardanoDBExtended = true;
   withHighCapacityMonitoring = true;

--- a/nix/topology-lib.nix
+++ b/nix/topology-lib.nix
@@ -134,7 +134,7 @@ pkgs: with pkgs; with lib; rec {
     }) topologies;
 
   /* return registered tird-party relays, as saved in static/registered_relays_topology.json from
-     https://${globals.explorerHostName}.${globals.domain}/relays/topology.json
+     https://${globals.explorerHostName}/relays/topology.json
   */
   thirdPartyRelays = globals.static.additionalPeers ++
     (filter (r: !(hasSuffix globals.relaysNew r.addr))

--- a/pkgs/node-update/src/node-update.cr
+++ b/pkgs/node-update/src/node-update.cr
@@ -77,7 +77,7 @@ class RelayUpdate
       updateAbort("Unable to process the deployment name from the globals file.")
     end
 
-    if runCmdVerbose("nix eval --raw '(with import ./#{PATH_MOD}/nix {}; \"https://${globals.explorerHostName}.${globals.domain}/relays/topology.json\")'").success?
+    if runCmdVerbose("nix eval --raw '(with import ./#{PATH_MOD}/nix {}; \"https://${globals.explorerHostName}/relays/topology.json\")'").success?
       @explorerUrl = IO_CMD_OUT.to_s
     else
       updateAbort("Unable to process the explorer fqdn name from the globals file.")

--- a/roles/explorer.nix
+++ b/roles/explorer.nix
@@ -242,7 +242,7 @@ in {
       }
     '';
     virtualHosts = {
-      "${globals.explorerHostName}.${globals.domain}" = {
+      "${globals.explorerHostName}" = {
         serverAliases = globals.explorerAliases;
         enableACME = true;
         forceSSL = globals.explorerForceSSL;
@@ -285,7 +285,7 @@ in {
           "/" = {
             root = (cardano-explorer-app-pkgs.overrideScope'(self: super: {
               static = super.static.override {
-                graphqlApiHost = "${globals.explorerHostName}.${globals.domain}";
+                graphqlApiHost = globals.explorerHostName;
                 cardanoNetwork = globals.environmentName;
                 gaTrackingId = globals.static.gaTrackingId or null;
               };

--- a/topologies/mainnet-candidate-4.nix
+++ b/topologies/mainnet-candidate-4.nix
@@ -102,7 +102,7 @@ in {
   };
 
   explorer = withDailyRestart {
-    services.nginx.virtualHosts."${globals.explorerHostName}.${globals.domain}".locations."/p" = lib.mkIf (__pathExists ../static/pool-metadata) {
+    services.nginx.virtualHosts.${globals.explorerHostName}.locations."/p" = lib.mkIf (__pathExists ../static/pool-metadata) {
       root = ../static/pool-metadata;
     };
   };

--- a/topologies/shelley-qa.nix
+++ b/topologies/shelley-qa.nix
@@ -68,7 +68,7 @@ in {
 
 
   explorer = {
-    services.nginx.virtualHosts."${globals.explorerHostName}.${globals.domain}".locations."/p" = lib.mkIf (__pathExists ../static/pool-metadata) {
+    services.nginx.virtualHosts.${globals.explorerHostName}.locations."/p" = lib.mkIf (__pathExists ../static/pool-metadata) {
       root = ../static/pool-metadata;
     };
     services.cardano-graphql = {

--- a/topologies/testnet.nix
+++ b/topologies/testnet.nix
@@ -103,7 +103,7 @@ in {
     };
   };
   explorer = {
-    services.nginx.virtualHosts."${globals.explorerHostName}.${globals.domain}".locations."/p" = lib.mkIf (__pathExists ../static/pool-metadata) {
+    services.nginx.virtualHosts.${globals.explorerHostName}.locations."/p" = lib.mkIf (__pathExists ../static/pool-metadata) {
       root = ../static/pool-metadata;
     };
   };


### PR DESCRIPTION
 because cross-domains queries are not supported yet.
(https://github.com/input-output-hk/cardano-graphql/issues/392)

This allows https://explorer.cardano.org to work (but https://explorer.cardano-mainnet.iohk.io/ will not anymore) with introspection disabled and allowList enabled properly (fixed in https://github.com/input-output-hk/cardano-ops/pull/334).
