### PR TITLE
chore: changes for cardano-graphql 3.2 compatibility

### DIFF
--- a/roles/explorer.nix
+++ b/roles/explorer.nix
@@ -49,9 +49,11 @@ in {
 
   services.graphql-engine.enable = true;
   services.cardano-graphql = {
+    cardanoCliPath = cardano-cli + /bin/cardano-cli;
     enable = true;
     genesisByron = nodeCfg.nodeConfig.ByronGenesisFile;
     genesisShelley = nodeCfg.nodeConfig.ShelleyGenesisFile;
+    jqPath = jq;
     allowListPath = cardano-explorer-app-pkgs.allowList;
     cardanoNodeSocketPath = nodeCfg.socketPath;
   };


### PR DESCRIPTION
Adds `cardano-cli` and `jq` path configuration mapping. To be tested with https://github.com/input-output-hk/cardano-graphql/pull/386