### PR TITLE
Use seperate journald namespace for nginx and legacy verbose service.

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -150,10 +150,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "nixpkgs",
-        "rev": "4dfd084d19a270e5f962afa1851861c09522b222",
-        "sha256": "1dlcgr4af4cqaw5gs69vg9nfvfpnb7g3sls4cyw2iyqlijv5svqr",
+        "rev": "49fbe8b1fd816a49ff363fea3f7761c6881ae996",
+        "sha256": "0gl2id7nwrxq8db7x0qwp46gh5ry0nw42rrwd6y3d493dml9ycp4",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/nixpkgs/archive/4dfd084d19a270e5f962afa1851861c09522b222.tar.gz",
+        "url": "https://github.com/input-output-hk/nixpkgs/archive/49fbe8b1fd816a49ff363fea3f7761c6881ae996.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-crystal": {

--- a/roles/metadata.nix
+++ b/roles/metadata.nix
@@ -206,9 +206,6 @@ in {
     '';
   };
 
-  # Ensure that nginx doesn't hit a file limit with handling cache files
-  systemd.services.nginx.serviceConfig.LimitNOFILE = 65535;
-
   services.nginx = {
     enable = true;
     package = nginxMetadataServer;
@@ -290,6 +287,10 @@ in {
       };
     };
   };
+
+  # Avoid flooding (and rotating too quicky) default journal with nginx logs.
+  # nginx logs: journalctl --namespace nginx
+  systemd.services.nginx.serviceConfig.LogNamespace = "nginx";
 
   services.monitoring-exporters.extraPrometheusExporters = [
     #{


### PR DESCRIPTION
 to avoid flooding (and rotating too quicky) default journal.
 Also removed leftover, pre-varnish, LimitNOFILE settings for nginx.