### PR TITLE
create-genesis-and-keys: Set DPARAM to 1 at genesis.

### DIFF
--- a/scripts/create-genesis-and-keys.sh
+++ b/scripts/create-genesis-and-keys.sh
@@ -28,7 +28,7 @@ cd "$(dirname "$0")/.."
 export NB_CORE_NODES=$(($NB_BFT_NODES + $NB_POOL_NODES))
 DELAY="${DELAY:-30}"
 UTXO_KEYS="${UTXO_KEYS:-1}"
-DPARAM="${DPARAM:-$(awk "BEGIN{print 1.0 - 1.0 * $NB_POOL_NODES / $NB_CORE_NODES}")}"
+DPARAM="${DPARAM:-1}"
 
 echo "Generating new genesis and keys using following environments variables:
 


### PR DESCRIPTION
We can't set up the stake pools until after we're in Shelley, but
decentralisationParam takes effect immediately. This results in the
initial Shelley epochs having too few blocks, breaking invariants.

New testnets should wait until stake pools are up and running and then
update the decentralisationParam with an update proposal (perhaps at
the same time as the move to Allegra)