### PR TITLE
Fixes typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 NixOps deployment configuration for IOHK/Cardano devops.
 
 For examples on how you can deploy your own testnet please refer to the
-[REAME](examples/shelley-testnet/README.md) of the Shelley testnet example.
+[README](examples/shelley-testnet/README.md) of the Shelley testnet example.
 
 ## Explorer upgrades
 


### PR DESCRIPTION
Fixes a typo where it was written 'REAME' instead of 'README'