### PR TITLE
decrease node instances and increase relays

### DIFF
--- a/globals-defaults.nix
+++ b/globals-defaults.nix
@@ -159,10 +159,10 @@ in {
   };
 
   alertChainDensityLow = "99";
-  alertTcpHigh = 333 * pkgs.globals.nbInstancesPerRelay;
-  alertTcpCrit = 500 * pkgs.globals.nbInstancesPerRelay;
-  alertMbpsHigh = 150 * pkgs.globals.nbInstancesPerRelay;
-  alertMbpsCrit = 200 * pkgs.globals.nbInstancesPerRelay;
+  alertTcpHigh = 165 * globals.ec2.instances.relay-node.node.cpus;
+  alertTcpCrit = 250 * globals.ec2.instances.relay-node.node.cpus;
+  alertMbpsHigh = 75 * globals.ec2.instances.relay-node.node.cpus;
+  alertMbpsCrit = 100 * globals.ec2.instances.relay-node.node.cpus;
   alertHighBlockUtilization = 95; # Alert if blocks are above that % full.
 
 

--- a/globals-mainnet.nix
+++ b/globals-mainnet.nix
@@ -41,7 +41,7 @@ pkgs: {
     CF = 36;
   };
 
-  minMemoryPerInstance = 10;
+  minMemoryPerInstance = 15;
 
   # GB per node instance
   nodeDbDiskAllocationSize = 140;
@@ -59,8 +59,6 @@ pkgs: {
       core-node = r5-large;
     };
   };
-
-  nbInstancesPerRelay = 2;
 
   relayUpdateArgs = "-m 3200 --maxNodes 11 -s -e devops@iohk.io";
   # Trigger relay topology refresh 12 hours before next epoch

--- a/globals-mainnet.nix
+++ b/globals-mainnet.nix
@@ -60,6 +60,8 @@ pkgs: {
     };
   };
 
+  nbInstancesPerRelay = 2;
+
   relayUpdateArgs = "-m 3200 --maxNodes 11 -s -e devops@iohk.io";
   # Trigger relay topology refresh 12 hours before next epoch
   relayUpdateHoursBeforeNextEpoch = 12;

--- a/modules/base-service.nix
+++ b/modules/base-service.nix
@@ -78,6 +78,10 @@ in
         type = types.float;
         default = config.node.memory * 1024 * 0.875;
       };
+      totalCpuCores = mkOption {
+        type = types.int;
+        default = min config.node.cpus (2 * cfg.instances);
+      };
       maxIntraInstancesPeers = mkOption {
         type = types.int;
         default = 5;
@@ -115,7 +119,7 @@ in
       enable = true;
       systemdSocketActivation = true;
       # https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/runtime_control.html
-      rtsArgs = [ "-N2" "-A16m" "-qg" "-qb" "-M${toString (cfg.totalMaxHeapSizeMbytes / cfg.instances)}M" ];
+      rtsArgs = [ "-N${toString (cfg.totalCpuCores / cfg.instances)}" "-A16m" "-qg" "-qb" "-M${toString (cfg.totalMaxHeapSizeMbytes / cfg.instances)}M" ];
       environment = globals.environmentName;
       cardanoNodePkgs = lib.mkDefault cardanoNodePkgs;
       inherit hostAddr nodeId instanceProducers instancePublicProducers;

--- a/roles/relay.nix
+++ b/roles/relay.nix
@@ -10,6 +10,7 @@ pkgs: with pkgs; {config, ...}: {
 
   services.cardano-node = {
     instances = lib.mkDefault globals.nbInstancesPerRelay;
+    totalCpuCores = lib.mkDefault config.node.cpus;
     extraServiceConfig = _: {
       # Since multiple node instances might monopolize CPU, preventing ssh access, lower nice priority:
       serviceConfig.Nice = 5;

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -9,22 +9,22 @@ let
 
   regions = {
     a = { name = "eu-central-1";   # Europe (Frankfurt);
-      minRelays = 35;
+      minRelays = 52;
     };
     b = { name = "us-east-2";      # US East (Ohio)
-      minRelays = 25;
+      minRelays = 37;
     };
     c = { name = "ap-southeast-1"; # Asia Pacific (Singapore)
-      minRelays = 10;
+      minRelays = 15;
     };
     d = { name = "eu-west-2";      # Europe (London)
-      minRelays = 15;
+      minRelays = 22;
     };
     e = { name = "us-west-1";      # US West (N. California)
-      minRelays = 15;
+      minRelays = 22;
     };
     f = { name = "ap-northeast-1"; # Asia Pacific (Tokyo)
-      minRelays = 10;
+      minRelays = 15;
     };
   };
 

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -9,22 +9,22 @@ let
 
   regions = {
     a = { name = "eu-central-1";   # Europe (Frankfurt);
-      minRelays = 52;
+      minRelays = 35;
     };
     b = { name = "us-east-2";      # US East (Ohio)
-      minRelays = 37;
+      minRelays = 25;
     };
     c = { name = "ap-southeast-1"; # Asia Pacific (Singapore)
-      minRelays = 15;
+      minRelays = 10;
     };
     d = { name = "eu-west-2";      # Europe (London)
-      minRelays = 22;
+      minRelays = 15;
     };
     e = { name = "us-west-1";      # US West (N. California)
-      minRelays = 22;
+      minRelays = 15;
     };
     f = { name = "ap-northeast-1"; # Asia Pacific (Tokyo)
-      minRelays = 15;
+      minRelays = 10;
     };
   };
 


### PR DESCRIPTION
Relays have maxed out RAM available to `t3.2xlarge` instance types.

This PR reduces the number of node instances per relay from 3 to 2.

It compensates for this instance reduction by increasing `minRelays` relatively.