### PR TITLE
p2p topo and topo-fn updates, misc improvements

### DIFF
--- a/modules/base-service.nix
+++ b/modules/base-service.nix
@@ -13,7 +13,7 @@ let
 
   splitProducers = partition (n: nodes ? ${n.addr or n}) cfg.allProducers;
   deployedProducers = splitProducers.right;
-  thirdParyProducers = splitProducers.wrong;
+  thirdPartyProducers = splitProducers.wrong;
   splitDeployed = partition (n: nodes.${n}.config.node.roles.isCardanoCore) deployedProducers;
   coreNodeProducers = splitDeployed.right;
   relayNodeProducers = splitDeployed.wrong;
@@ -69,13 +69,13 @@ let
       (producerShare i coreNodeProducers)
     ]))) ++ lib.optionals cfg.useInstancePublicProducersAsProducers (
       lib.flatten (map toNormalizedProducerGroup (filter (g: length g != 0) [
-        (producerShare (cfg.instances - i - 1) thirdParyProducers)
+        (producerShare (cfg.instances - i - 1) thirdPartyProducers)
       ]))
     );
 
   instancePublicProducers = i: lib.optionals (!cfg.useInstancePublicProducersAsProducers)
     (lib.flatten (map toNormalizedProducerGroup (filter (g: length g != 0) [
-      (producerShare (cfg.instances - i - 1) thirdParyProducers)
+      (producerShare (cfg.instances - i - 1) thirdPartyProducers)
     ])));
 
 in

--- a/modules/base-service.nix
+++ b/modules/base-service.nix
@@ -26,15 +26,27 @@ let
     ip = staticRouteIp nodeName;
   }) deployedProducers;
 
-  toNormalizedProducerGroup = producers: {
-    accessPoints = map (n: {
+  toNormalizedProducerGroup = producers: let
+    mkAccessPointsElement = n: {
       address = let a = n.addr or n; in if (nodes ? ${a}) then hostName a else a;
       port = n.port or nodePort;
     } // lib.optionalAttrs (!cfg.useNewTopology) {
       valency = n.valency or 1;
+    };
+
+    mkAccessPoints = producers: {
+      accessPoints = map (n: mkAccessPointsElement n) producers;
+      valency = length producers;
+    };
+
+    mkSingleMemberAccessPoints = producers: map (n: {
+      accessPoints = [(mkAccessPointsElement n)];
+      valency = n.valency or 1;
     }) producers;
-    valency = length producers;
-  };
+  in if cfg.useSingleMemberAccessPoints then
+    mkSingleMemberAccessPoints producers
+  else
+    mkAccessPoints producers;
 
   producerShare = i: producers: let
       indexed = imap0 (idx: node: { inherit idx node;}) producers;
@@ -45,19 +57,26 @@ let
     cfg.maxIntraInstancesPeers
     (genList (i: {name = i;}) cfg.instances);
 
-  instanceProducers = i: map toNormalizedProducerGroup (filter (g: length g != 0) [
+  instanceProducers = i: (lib.flatten (map toNormalizedProducerGroup (filter (g: length g != 0) [
       (concatMap (i: map (p: {
         addr = cfg.ipv6HostAddr p;
-        port = cfg.port + p;
+        port = if cfg.shareIpv6port
+          then cfg.port
+          else cfg.port + p;
       }) i.producers) (filter (x: x.name == i) intraInstancesTopologies))
       (producerShare i sameRegionRelays)
       (producerShare (cfg.instances - i - 1) otherRegionRelays)
       (producerShare i coreNodeProducers)
-    ]);
+    ]))) ++ lib.optionals cfg.useInstancePublicProducersAsProducers (
+      lib.flatten (map toNormalizedProducerGroup (filter (g: length g != 0) [
+        (producerShare (cfg.instances - i - 1) thirdParyProducers)
+      ]))
+    );
 
-  instancePublicProducers = i: map toNormalizedProducerGroup (filter (g: length g != 0) [
-    (producerShare (cfg.instances - i - 1) thirdParyProducers)
-  ]);
+  instancePublicProducers = i: lib.optionals (!cfg.useInstancePublicProducersAsProducers)
+    (lib.flatten (map toNormalizedProducerGroup (filter (g: length g != 0) [
+      (producerShare (cfg.instances - i - 1) thirdParyProducers)
+    ])));
 
 in
 {
@@ -70,22 +89,54 @@ in
   options = {
     services.cardano-node = {
       publicIp = mkOption { type = types.str; default = staticRouteIp name;};
+
       allProducers = mkOption {
         default = [];
         type = types.listOf (types.either types.str types.attrs);
         description = ''Static routes to peers.'';
       };
+
       totalMaxHeapSizeMbytes = mkOption {
         type = types.float;
         default = config.node.memory * 1024 * 0.790;
       };
+
       totalCpuCores = mkOption {
         type = types.int;
         default = min config.node.cpus (2 * cfg.instances);
       };
+
       maxIntraInstancesPeers = mkOption {
         type = types.int;
         default = 5;
+      };
+
+      shareIpv6Address = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Should instances on same machine share ipv6 address.
+          Default: true, sets ipv6HostAddr equal to ::1.
+          If false use address increments starting from instance index + 1.
+        '';
+      };
+
+      useSingleMemberAccessPoints = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If set true with useNewTopology enabled, a p2p localRoots or publicRoots
+          element with n target members in accessPoints will instead be written as n
+          localRoots or publicRoots elements each with 1 target member in accessPoints.
+        '';
+      };
+
+      useInstancePublicProducersAsProducers = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If set true with useNewTopology enabled, p2p publicRoots will become localRoots.
+        '';
       };
     };
   };
@@ -124,7 +175,10 @@ in
       environment = globals.environmentName;
       cardanoNodePackages = lib.mkDefault cardanoNodePackages;
       inherit hostAddr nodeId instanceProducers instancePublicProducers;
-      ipv6HostAddr = mkIf (cfg.instances > 1) "::1";
+      ipv6HostAddr = mkIf (cfg.instances > 1) (
+        if cfg.shareIpv6Address then "::1"
+        else (i: "::127.0.0.${toString (i + 1)}")
+      );
       producers = mkDefault [];
       publicProducers = mkDefault [];
       port = nodePort;

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -12,6 +12,7 @@ self: super: with self; {
       if (nodes.${nodeName}.options.networking.publicIPv4.isDefined && publicIp != null) then publicIp
       else (builtins.trace "No public IP found for node: ${nodeName}" "")
     );
+
   getStaticRouteIp = resources: nodes: nodeName: resources.elasticIPs."${nodeName}-ip".address
     or (let
       publicIp = nodes.${nodeName}.config.networking.publicIPv4;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,15 +180,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node-service": {
-        "branch": "refs/tags/8.1.1",
+        "branch": "nixos-service-mixed-p2p",
         "description": "The core component that is used to participate in a Cardano decentralised blockchain.",
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "6f79e5c3ea109a70cd01910368e011635767305a",
-        "sha256": "1kl4dw7b361db6ryfjjl0w5cm936h9jwy8d94191bnar13wvs9i4",
+        "rev": "d239bd5a268ecace90b7df14b51227d174153dd5",
+        "sha256": "1c6pvypv4s1k4niwi4r48a2vhwzaw0asggbb1ppz94kq1njai6a3",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/6f79e5c3ea109a70cd01910368e011635767305a.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/d239bd5a268ecace90b7df14b51227d174153dd5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-rosetta-1.6": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -132,15 +132,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node": {
-        "branch": "refs/tags/8.1.1",
+        "branch": "refs/tags/8.1.2",
         "description": null,
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "6f79e5c3ea109a70cd01910368e011635767305a",
-        "sha256": "1kl4dw7b361db6ryfjjl0w5cm936h9jwy8d94191bnar13wvs9i4",
+        "rev": "d2d90b48c5577b4412d5c9c9968b55f8ab4b9767",
+        "sha256": "1qpmlfxdfx2dg12109cyn75ybcwxjz0wk451pzcalfdzxhvpqibp",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/6f79e5c3ea109a70cd01910368e011635767305a.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/d2d90b48c5577b4412d5c9c9968b55f8ab4b9767.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node-1-33-0rc3": {
@@ -168,15 +168,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node-next": {
-        "branch": "refs/tags/8.1.1",
+        "branch": "refs/tags/8.1.2",
         "description": "The core component that is used to participate in a Cardano decentralised blockchain.",
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "6f79e5c3ea109a70cd01910368e011635767305a",
-        "sha256": "1kl4dw7b361db6ryfjjl0w5cm936h9jwy8d94191bnar13wvs9i4",
+        "rev": "d2d90b48c5577b4412d5c9c9968b55f8ab4b9767",
+        "sha256": "1qpmlfxdfx2dg12109cyn75ybcwxjz0wk451pzcalfdzxhvpqibp",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/6f79e5c3ea109a70cd01910368e011635767305a.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/d2d90b48c5577b4412d5c9c9968b55f8ab4b9767.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node-service": {

--- a/roles/snapshots.nix
+++ b/roles/snapshots.nix
@@ -15,6 +15,20 @@ in {
     })
   ];
 
+  # Use sigint for a clean stop signal
+  #
+  # This will result in success status on the next release after 8.1.1 for SIGINT,
+  # whereas SIGTERM will still return 1 despite otherwise clean exit.
+  #
+  # Until then, temporarily force recognition of RC 1 as success for snapshots automation,
+  # as clean service stoppage is expected to return 1.
+  #
+  # Refs:
+  #  https://github.com/input-output-hk/cardano-node/issues/5312
+  #  https://github.com/input-output-hk/cardano-node/pull/5356
+  systemd.services.cardano-node.serviceConfig.KillSignal = "SIGINT";
+  systemd.services.cardano-node.serviceConfig.SuccessExitStatus = "FAILURE";
+
   # Create a new snapshot every 24h (if not exist alreay):
   services.cardano-db-sync.takeSnapshot = "always";
 

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -26,21 +26,27 @@ let
   regions = {
     a = { name = "eu-central-1";   # Europe (Frankfurt);
       minRelays = 40;
+      nbRelaysExcludingThirdParty = 1;
     };
     b = { name = "us-east-2";      # US East (Ohio)
       minRelays = 25;
+      nbRelaysExcludingThirdParty = 1;
     };
     c = { name = "ap-southeast-1"; # Asia Pacific (Singapore)
       minRelays = 10;
+      nbRelaysExcludingThirdParty = 1;
     };
     d = { name = "eu-west-2";      # Europe (London)
       minRelays = 15;
+      nbRelaysExcludingThirdParty = 1;
     };
     e = { name = "us-west-1";      # US West (N. California)
       minRelays = 15;
+      nbRelaysExcludingThirdParty = 1;
     };
     f = { name = "ap-northeast-1"; # Asia Pacific (Tokyo)
       minRelays = 10;
+      nbRelaysExcludingThirdParty = 1;
     };
   };
 
@@ -166,8 +172,8 @@ let
         # Make 3rd party producers localRoots rather than publicRoots for a 1:1 equivalency with legacy topology.
         useInstancePublicProducersAsProducers = true;
 
-        # Don't use any chain source outside of declared localRoots until after slot correlating with ~2023-07-04 21:44Z:
-        usePeersFromLedgerAfterSlot = 96940733;
+        # Don't use any chain source outside of declared localRoots until after slot correlating with ~2023-07-14 21:44:58Z:
+        usePeersFromLedgerAfterSlot = 97804807;
 
         # Ensure p2p relay node instances utilize the same number of producers as legacy relays as best as possible
         extraNodeConfig.TargetNumberOfActivePeers = maxProducersPerNode;

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -166,20 +166,20 @@ let
         # Make 3rd party producers localRoots rather than publicRoots for a 1:1 equivalency with legacy topology.
         useInstancePublicProducersAsProducers = true;
 
-        # Don't use any chain source outside of declared localRoots until after slot correlating with ~2023-06-24 21:44Z:
-        usePeersFromLedgerAfterSlot = 96076788;
+        # Don't use any chain source outside of declared localRoots until after slot correlating with ~2023-07-04 21:44Z:
+        usePeersFromLedgerAfterSlot = 96940733;
 
         # Ensure p2p relay node instances utilize the same number of producers as legacy relays as best as possible
         extraNodeConfig.TargetNumberOfActivePeers = maxProducersPerNode;
       };
     } (lib.flatten [
       # See the nixops deploy [--build-only] [--include ...] trace for calculated p2p percentages per region.
-      (p2pRelayRegionList "a" 8) # Currently 40 total region a relays, each represents 2.5% of region total
-      (p2pRelayRegionList "b" 5) # Currently 25 total region b relays, each represents 4.0% of region total
-      (p2pRelayRegionList "c" 2) # Currently 10 total region c relays, each represents 10.0% of region total
-      (p2pRelayRegionList "d" 3) # Currently 15 total region d relays, each represents 6.67% of region total
-      (p2pRelayRegionList "e" 3) # Currently 15 total region e relays, each represents 6.67% of region total
-      (p2pRelayRegionList "f" 2) # Currently 10 total region f relays, each represents 10.0% of region total
+      (p2pRelayRegionList "a" 12) # Currently 40 total region a relays, each represents 2.5% of region total
+      (p2pRelayRegionList "b" 8) # Currently 25 total region b relays, each represents 4.0% of region total
+      (p2pRelayRegionList "c" 3) # Currently 10 total region c relays, each represents 10.0% of region total
+      (p2pRelayRegionList "d" 5) # Currently 15 total region d relays, each represents 6.67% of region total
+      (p2pRelayRegionList "e" 5) # Currently 15 total region e relays, each represents 6.67% of region total
+      (p2pRelayRegionList "f" 3) # Currently 10 total region f relays, each represents 10.0% of region total
     ]))
   ]) (
     map (withModule {

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -174,12 +174,12 @@ let
       };
     } (lib.flatten [
       # See the nixops deploy [--build-only] [--include ...] trace for calculated p2p percentages per region.
-      (p2pRelayRegionList "a" 12) # Currently 40 total region a relays, each represents 2.5% of region total
-      (p2pRelayRegionList "b" 8) # Currently 25 total region b relays, each represents 4.0% of region total
-      (p2pRelayRegionList "c" 3) # Currently 10 total region c relays, each represents 10.0% of region total
-      (p2pRelayRegionList "d" 5) # Currently 15 total region d relays, each represents 6.67% of region total
-      (p2pRelayRegionList "e" 5) # Currently 15 total region e relays, each represents 6.67% of region total
-      (p2pRelayRegionList "f" 3) # Currently 10 total region f relays, each represents 10.0% of region total
+      (p2pRelayRegionList "a" 16) # Currently 40 total region a relays, each represents 2.5% of region total
+      (p2pRelayRegionList "b" 10) # Currently 25 total region b relays, each represents 4.0% of region total
+      (p2pRelayRegionList "c" 4) # Currently 10 total region c relays, each represents 10.0% of region total
+      (p2pRelayRegionList "d" 6) # Currently 15 total region d relays, each represents 6.67% of region total
+      (p2pRelayRegionList "e" 6) # Currently 15 total region e relays, each represents 6.67% of region total
+      (p2pRelayRegionList "f" 4) # Currently 10 total region f relays, each represents 10.0% of region total
     ]))
   ]) (
     map (withModule {

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -174,12 +174,12 @@ let
       };
     } (lib.flatten [
       # See the nixops deploy [--build-only] [--include ...] trace for calculated p2p percentages per region.
-      (p2pRelayRegionList "a" 4) # Currently 40 total region a relays, each represents 2.5% of region total
-      (p2pRelayRegionList "b" 3) # Currently 25 total region b relays, each represents 4.0% of region total
-      (p2pRelayRegionList "c" 1) # Currently 10 total region c relays, each represents 10.0% of region total
-      (p2pRelayRegionList "d" 2) # Currently 15 total region d relays, each represents 6.67% of region total
-      (p2pRelayRegionList "e" 2) # Currently 15 total region e relays, each represents 6.67% of region total
-      (p2pRelayRegionList "f" 1) # Currently 10 total region f relays, each represents 10.0% of region total
+      (p2pRelayRegionList "a" 8) # Currently 40 total region a relays, each represents 2.5% of region total
+      (p2pRelayRegionList "b" 5) # Currently 25 total region b relays, each represents 4.0% of region total
+      (p2pRelayRegionList "c" 2) # Currently 10 total region c relays, each represents 10.0% of region total
+      (p2pRelayRegionList "d" 3) # Currently 15 total region d relays, each represents 6.67% of region total
+      (p2pRelayRegionList "e" 3) # Currently 15 total region e relays, each represents 6.67% of region total
+      (p2pRelayRegionList "f" 2) # Currently 10 total region f relays, each represents 10.0% of region total
     ]))
   ]) (
     map (withModule {

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -174,12 +174,12 @@ let
       };
     } (lib.flatten [
       # See the nixops deploy [--build-only] [--include ...] trace for calculated p2p percentages per region.
-      (p2pRelayRegionList "a" 16) # Currently 40 total region a relays, each represents 2.5% of region total
-      (p2pRelayRegionList "b" 10) # Currently 25 total region b relays, each represents 4.0% of region total
-      (p2pRelayRegionList "c" 4) # Currently 10 total region c relays, each represents 10.0% of region total
-      (p2pRelayRegionList "d" 6) # Currently 15 total region d relays, each represents 6.67% of region total
-      (p2pRelayRegionList "e" 6) # Currently 15 total region e relays, each represents 6.67% of region total
-      (p2pRelayRegionList "f" 4) # Currently 10 total region f relays, each represents 10.0% of region total
+      (p2pRelayRegionList "a" 20) # Currently 40 total region a relays, each represents 2.5% of region total
+      (p2pRelayRegionList "b" 13) # Currently 25 total region b relays, each represents 4.0% of region total
+      (p2pRelayRegionList "c" 5) # Currently 10 total region c relays, each represents 10.0% of region total
+      (p2pRelayRegionList "d" 8) # Currently 15 total region d relays, each represents 6.67% of region total
+      (p2pRelayRegionList "e" 8) # Currently 15 total region e relays, each represents 6.67% of region total
+      (p2pRelayRegionList "f" 5) # Currently 10 total region f relays, each represents 10.0% of region total
     ]))
   ]) (
     map (withModule {


### PR DESCRIPTION
* Adds p2p functions to enable mixed legacy and p2p topology
* Improve EBS resize script
* Workaround snapshots node rc until > 8.1
* Adds nbRelaysExcludingThirdParty opt for p2p spare ledgerSlots
* Sets mainnet topology to 50% p2p and 1 dedicated ledger peers p2p relay per region
* General cleanup
* Bumps cardano-node, cardano-node-next -> 8.1.2