### PR TITLE
Node 8.7.2 update and misc improvements

### DIFF
--- a/clusters/cardano.nix
+++ b/clusters/cardano.nix
@@ -101,6 +101,26 @@ let
       imports = [
         (def.instance or instances.snapshots)
         cardano-ops.roles.snapshots
+        (pkgs: let
+          iohkNix812 = import (import ../nix/sources.nix { inherit pkgs; })."iohk-nix-node-8.1.2" {};
+        in {
+          # Correct the difference between the new iohk-nix for 8.7.2 and the legacy iohk-nix still required for dbsync on node 8.1.2
+          services.cardano-node = {
+            useNewTopology = false;
+            environments = {
+              "${globals.environmentName}" = iohkNix812.cardanoLib.environments.${globals.environmentName};
+            };
+            nodeConfig = iohkNix812.cardanoLib.environments.${globals.environmentName}.nodeConfig;
+            extraNodeConfig.EnableP2P = false;
+            producers = pkgs.lib.mkForce [];
+            publicProducers = pkgs.lib.mkForce [{accessPoints = [{address = "europe.relays-new.cardano-mainnet.iohk.io"; port = 3001; valency = 2;}];}];
+          };
+
+          services.cardano-db-sync = {
+            environment = iohkNix812.cardanoLib.environments.${globals.environmentName};
+            logConfig = iohkNix812.cardanoLib.defaultExplorerLogConfig // { PrometheusPort = globals.cardanoExplorerPrometheusExporterPort; };
+          };
+        })
       ];
 
       node = {

--- a/clusters/cardano.nix
+++ b/clusters/cardano.nix
@@ -101,26 +101,6 @@ let
       imports = [
         (def.instance or instances.snapshots)
         cardano-ops.roles.snapshots
-        (pkgs: let
-          iohkNix812 = import (import ../nix/sources.nix { inherit pkgs; })."iohk-nix-node-8.1.2" {};
-        in {
-          # Correct the difference between the new iohk-nix for 8.7.2 and the legacy iohk-nix still required for dbsync on node 8.1.2
-          services.cardano-node = {
-            useNewTopology = false;
-            environments = {
-              "${globals.environmentName}" = iohkNix812.cardanoLib.environments.${globals.environmentName};
-            };
-            nodeConfig = iohkNix812.cardanoLib.environments.${globals.environmentName}.nodeConfig;
-            extraNodeConfig.EnableP2P = false;
-            producers = pkgs.lib.mkForce [];
-            publicProducers = pkgs.lib.mkForce [{accessPoints = [{address = "europe.relays-new.cardano-mainnet.iohk.io"; port = 3001; valency = 2;}];}];
-          };
-
-          services.cardano-db-sync = {
-            environment = iohkNix812.cardanoLib.environments.${globals.environmentName};
-            logConfig = iohkNix812.cardanoLib.defaultExplorerLogConfig // { PrometheusPort = globals.cardanoExplorerPrometheusExporterPort; };
-          };
-        })
       ];
 
       node = {

--- a/globals-defaults.nix
+++ b/globals-defaults.nix
@@ -67,6 +67,7 @@ in {
   };
   explorer13-1 = globals.explorer13 // {
     cardano-db-sync = sourcePaths."cardano-db-sync-13-1";
+    cardano-node = sourcePaths."cardano-node-8.1.2";
   };
 
   explorerBackendsInContainers = false;

--- a/globals-mainnet.nix
+++ b/globals-mainnet.nix
@@ -6,6 +6,10 @@ pkgs: {
 
   domain = "cardano-mainnet.iohk.io";
 
+  # Override relaysNew with the legacy FQDN since the 8.7.2
+  # iohk-nix pin contains an updated backbone CNAME reference
+  relaysNew = "relays-new.cardano-mainnet.iohk.io";
+
   # Explorer gateway and backends have moved to ci-world
   withExplorer = false;
   explorerHostName = "explorer.cardano.org";

--- a/modules/base-service.nix
+++ b/modules/base-service.nix
@@ -149,7 +149,12 @@ in
     };
     services.monitoring-exporters.extraPrometheusExporters = genList (i: {
       job_name = "cardano-node";
-      scrape_interval = "10s";
+
+      # Longer interval and timeout required for node metrics which
+      # can be substantially delayed in response when under high load
+      scrape_interval = "60s";
+      scrape_timeout = "60s";
+
       port = monitoringPort + i;
       metrics_path = "/metrics";
       labels = optionalAttrs (i > 0) { alias = "${name}.${toString i}"; };

--- a/modules/monitoring-cardano.nix
+++ b/modules/monitoring-cardano.nix
@@ -55,13 +55,13 @@ in {
     {
       alert = "High cardano ping latency";
       expr = "avg_over_time(cardano_ping_latency_ms[5m]) > 250";
-      for = "30m";
+      for = "45m";
       labels = {
         severity = "page";
       };
       annotations = {
-        summary =  "{{$labels.alias}}: Cardano average ping latency over 5 minutes has been above 250 milliseconds for the last 30 minutes";
-        description = "{{$labels.alias}}: Cardano average ping latency over 5 minutes has been above 250 milliseconds for the last 30 minutes.";
+        summary =  "{{$labels.alias}}: Cardano average ping latency over 5 minutes has been above 250 milliseconds for the last 45 minutes";
+        description = "{{$labels.alias}}: Cardano average ping latency over 5 minutes has been above 250 milliseconds for the last 45 minutes.";
       };
     }
     {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -180,15 +180,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node-next": {
-        "branch": "refs/tags/8.1.2",
+        "branch": "refs/tags/8.7.2",
         "description": "The core component that is used to participate in a Cardano decentralised blockchain.",
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "d2d90b48c5577b4412d5c9c9968b55f8ab4b9767",
-        "sha256": "1qpmlfxdfx2dg12109cyn75ybcwxjz0wk451pzcalfdzxhvpqibp",
+        "rev": "30b6e447c7e4586f43e30a68fe47c8481b0ba205",
+        "sha256": "1inhb3siys4n5k9j4w2vl9mwbq1digq86hh45v6bbrmvp5fy2aqd",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/d2d90b48c5577b4412d5c9c9968b55f8ab4b9767.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/30b6e447c7e4586f43e30a68fe47c8481b0ba205.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node-service": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -36,15 +36,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-db-sync-13-1": {
-        "branch": "13.1.0.2-majorminor-schema-version",
+        "branch": "refs/tags/13.1.1.3",
         "description": "A component that follows the Cardano chain and stores blocks and transactions in PostgreSQL",
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "cardano-db-sync",
-        "rev": "b84ac995b2a2645d36f6dad8f45900b587b04dab",
-        "sha256": "0nziszqvrc19xj1hy0247iigadzgpckbi2qb3fgfk3rd0l225fzq",
+        "rev": "6e69a80797f2d68423b25ca7787e81533b367e42",
+        "sha256": "1pfraykscmbdl428ilc1cac91fbvscjjbdzf5z5wc2gkff5r6cax",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-db-sync/archive/b84ac995b2a2645d36f6dad8f45900b587b04dab.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-db-sync/archive/6e69a80797f2d68423b25ca7787e81533b367e42.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-db-sync-service": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -353,10 +353,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "ops-lib",
-        "rev": "98f2d4f89ae3f6ced6f8188d0be4d3fde688701c",
-        "sha256": "08x5cjcpav063scgicc1g54067ybz3i26qb8mvxdgdjfdyccczxs",
+        "rev": "a53c592528bb1a4f7940e352fff4d43e786e0b6d",
+        "sha256": "1wvw6krl4mwrlm0d2j19ml02iqn7zd29gl5h4qac5j3iwi5j9mlg",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/ops-lib/archive/98f2d4f89ae3f6ced6f8188d0be4d3fde688701c.tar.gz",
+        "url": "https://github.com/input-output-hk/ops-lib/archive/a53c592528bb1a4f7940e352fff4d43e786e0b6d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -132,15 +132,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node": {
-        "branch": "refs/tags/8.1.2",
+        "branch": "refs/tags/8.7.2",
         "description": null,
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "d2d90b48c5577b4412d5c9c9968b55f8ab4b9767",
-        "sha256": "1qpmlfxdfx2dg12109cyn75ybcwxjz0wk451pzcalfdzxhvpqibp",
+        "rev": "30b6e447c7e4586f43e30a68fe47c8481b0ba205",
+        "sha256": "1inhb3siys4n5k9j4w2vl9mwbq1digq86hh45v6bbrmvp5fy2aqd",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/d2d90b48c5577b4412d5c9c9968b55f8ab4b9767.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/30b6e447c7e4586f43e30a68fe47c8481b0ba205.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node-1-33-0rc3": {
@@ -165,6 +165,18 @@
         "sha256": "1hr00wqzmcyc3x0kp2hyw78rfmimf6z4zd4vv85b9zv3nqbjgrik",
         "type": "tarball",
         "url": "https://github.com/input-output-hk/cardano-node/archive/814df2c146f5d56f8c35a681fe75e85b905aed5d.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "cardano-node-8.1.2": {
+        "branch": "refs/tags/8.1.2",
+        "description": "The core component that is used to participate in a Cardano decentralised blockchain.",
+        "homepage": "https://cardano.org",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "d2d90b48c5577b4412d5c9c9968b55f8ab4b9767",
+        "sha256": "1qpmlfxdfx2dg12109cyn75ybcwxjz0wk451pzcalfdzxhvpqibp",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/d2d90b48c5577b4412d5c9c9968b55f8ab4b9767.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node-next": {
@@ -252,6 +264,18 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
+        "branch": "master",
+        "description": "nix scripts shared across projects",
+        "homepage": null,
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "fbae4705ec10ed056146956f9ca94fac3a169c69",
+        "sha256": "0gskddlgx7s3gm5vvl72dmz862c2bx6yc8aqmjz9xdwfjpj4yi7v",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/fbae4705ec10ed056146956f9ca94fac3a169c69.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "iohk-nix-node-8.1.2": {
         "branch": "master",
         "description": "nix scripts shared across projects",
         "homepage": null,

--- a/roles/metadata.nix
+++ b/roles/metadata.nix
@@ -244,12 +244,12 @@ in {
     '';
     commonHttpConfig = ''
       log_format x-fwd '$remote_addr - $remote_user $sent_http_x_cache [$time_local] '
-                       '"$request" $status $body_bytes_sent '
+                       '"$request" $status $request_length $body_bytes_sent '
                        '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
 
       access_log syslog:server=unix:/dev/log x-fwd if=$loggable;
 
-      limit_req_zone $binary_remote_addr zone=metadataQueryPerIP:100m rate=10r/s;
+      limit_req_zone $binary_remote_addr zone=metadataQueryPerIP:100m rate=30r/s;
       limit_req_status 429;
       server_names_hash_bucket_size 128;
 

--- a/roles/snapshots.nix
+++ b/roles/snapshots.nix
@@ -32,6 +32,6 @@ in {
   # Create a new snapshot every 24h (if not exist alreay):
   services.cardano-db-sync.takeSnapshot = "always";
 
-  # Increase stop timeout to 3h, to allow for snapshot creation on mainnet
-  systemd.services.cardano-db-sync.serviceConfig.TimeoutStopSec = lib.mkForce "3h";
+  # Increase stop timeout to 6h, to allow for snapshot creation on mainnet
+  systemd.services.cardano-db-sync.serviceConfig.TimeoutStopSec = lib.mkForce "6h";
 }

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -26,27 +26,21 @@ let
   regions = {
     a = { name = "eu-central-1";   # Europe (Frankfurt);
       minRelays = 40;
-      nbRelaysExcludingThirdParty = 1;
     };
     b = { name = "us-east-2";      # US East (Ohio)
       minRelays = 25;
-      nbRelaysExcludingThirdParty = 1;
     };
     c = { name = "ap-southeast-1"; # Asia Pacific (Singapore)
       minRelays = 10;
-      nbRelaysExcludingThirdParty = 1;
     };
     d = { name = "eu-west-2";      # Europe (London)
       minRelays = 15;
-      nbRelaysExcludingThirdParty = 1;
     };
     e = { name = "us-west-1";      # US West (N. California)
       minRelays = 15;
-      nbRelaysExcludingThirdParty = 1;
     };
     f = { name = "ap-northeast-1"; # Asia Pacific (Tokyo)
       minRelays = 10;
-      nbRelaysExcludingThirdParty = 1;
     };
   };
 
@@ -184,12 +178,13 @@ let
       };
     } (lib.flatten [
       # See the nixops deploy [--build-only] [--include ...] trace for calculated p2p percentages per region.
-      (p2pRelayRegionList "a" 36) # Currently 40 total region a relays, each represents 2.5% of region total
-      (p2pRelayRegionList "b" 23) # Currently 25 total region b relays, each represents 4.0% of region total
-      (p2pRelayRegionList "c" 9) # Currently 10 total region c relays, each represents 10.0% of region total
-      (p2pRelayRegionList "d" 14) # Currently 15 total region d relays, each represents 6.67% of region total
-      (p2pRelayRegionList "e" 14) # Currently 15 total region e relays, each represents 6.67% of region total
-      (p2pRelayRegionList "f" 9) # Currently 10 total region f relays, each represents 10.0% of region total
+      # Leave one legacy topology relay as a canary, rel-a-1
+      (p2pRelayRegionList "a" 39) # Currently 40 total region a relays, each represents 2.5% of region total
+      (p2pRelayRegionList "b" 25) # Currently 25 total region b relays, each represents 4.0% of region total
+      (p2pRelayRegionList "c" 10) # Currently 10 total region c relays, each represents 10.0% of region total
+      (p2pRelayRegionList "d" 15) # Currently 15 total region d relays, each represents 6.67% of region total
+      (p2pRelayRegionList "e" 15) # Currently 15 total region e relays, each represents 6.67% of region total
+      (p2pRelayRegionList "f" 10) # Currently 10 total region f relays, each represents 10.0% of region total
     ]))
   ]) (
     map (withModule {

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -125,9 +125,9 @@ let
         };
       };
     } [ "rel-a-3" "rel-b-3" "rel-c-3" "rel-d-3" "rel-e-3" "rel-f-3" ])
-    (forNodes {
-      services.cardano-node.cardanoNodePackages = cardanoNodeNextPackages;
-    } [ "rel-a-4" "rel-b-4" "rel-c-4" "rel-d-4" "rel-e-4" "rel-f-4" ])
+    # (forNodes {
+    #   services.cardano-node.cardanoNodePackages = cardanoNodeNextPackages;
+    # } [ "rel-a-4" "rel-b-4" "rel-c-4" "rel-d-4" "rel-e-4" "rel-f-4" ])
     (forNodes {
       boot.kernel.sysctl."net.ipv4.tcp_slow_start_after_idle" = 0;
     } [ "rel-a-5" "rel-b-5" "rel-c-5" "rel-d-5" "rel-e-5" "rel-f-5" ])

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -91,6 +91,15 @@ let
 
   relayNodes = map (composeAll [
     (forNodes {
+      # Leave one legacy network topology canary
+      services.cardano-node = {
+        useNewTopology = false;
+        extraNodeInstanceConfig = i: {
+          EnableP2P = false;
+        };
+      };
+    } [ "rel-a-1" ])
+    (forNodes {
       services.cardano-node = {
         extraNodeInstanceConfig = i: optionalAttrs (i == 0) {
           TraceMempool = true;

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -180,12 +180,12 @@ let
       };
     } (lib.flatten [
       # See the nixops deploy [--build-only] [--include ...] trace for calculated p2p percentages per region.
-      (p2pRelayRegionList "a" 20) # Currently 40 total region a relays, each represents 2.5% of region total
-      (p2pRelayRegionList "b" 13) # Currently 25 total region b relays, each represents 4.0% of region total
-      (p2pRelayRegionList "c" 5) # Currently 10 total region c relays, each represents 10.0% of region total
-      (p2pRelayRegionList "d" 8) # Currently 15 total region d relays, each represents 6.67% of region total
-      (p2pRelayRegionList "e" 8) # Currently 15 total region e relays, each represents 6.67% of region total
-      (p2pRelayRegionList "f" 5) # Currently 10 total region f relays, each represents 10.0% of region total
+      (p2pRelayRegionList "a" 24) # Currently 40 total region a relays, each represents 2.5% of region total
+      (p2pRelayRegionList "b" 15) # Currently 25 total region b relays, each represents 4.0% of region total
+      (p2pRelayRegionList "c" 6) # Currently 10 total region c relays, each represents 10.0% of region total
+      (p2pRelayRegionList "d" 9) # Currently 15 total region d relays, each represents 6.67% of region total
+      (p2pRelayRegionList "e" 9) # Currently 15 total region e relays, each represents 6.67% of region total
+      (p2pRelayRegionList "f" 6) # Currently 10 total region f relays, each represents 10.0% of region total
     ]))
   ]) (
     map (withModule {

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -128,6 +128,10 @@ let
     (forNodes {
       boot.kernel.sysctl."net.ipv4.tcp_slow_start_after_idle" = 0;
     } [ "rel-a-5" "rel-b-5" "rel-c-5" "rel-d-5" "rel-e-5" "rel-f-5" ])
+    (forNodes {
+      systemd.services.cardano-node-0.serviceConfig.MemoryMax = lib.mkForce "13500M";
+      systemd.services.cardano-node-1.serviceConfig.MemoryMax = lib.mkForce "13000M";
+    } [ "rel-a-30" ])
 
     # Begin transitioning relays to p2p.
     # All node instances on each relay listed below will utilize p2p.

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -172,20 +172,20 @@ let
         # Make 3rd party producers localRoots rather than publicRoots for a 1:1 equivalency with legacy topology.
         useInstancePublicProducersAsProducers = true;
 
-        # Don't use any chain source outside of declared localRoots until after slot correlating with ~2023-08-18 21:44:53Z:
-        usePeersFromLedgerAfterSlot = 100828802;
+        # Don't use any chain source outside of declared localRoots until after slot correlating with ~2023-08-23 21:44:52Z:
+        usePeersFromLedgerAfterSlot = 101260801;
 
         # Ensure p2p relay node instances utilize the same number of producers as legacy relays as best as possible
         extraNodeConfig.TargetNumberOfActivePeers = maxProducersPerNode;
       };
     } (lib.flatten [
       # See the nixops deploy [--build-only] [--include ...] trace for calculated p2p percentages per region.
-      (p2pRelayRegionList "a" 32) # Currently 40 total region a relays, each represents 2.5% of region total
-      (p2pRelayRegionList "b" 20) # Currently 25 total region b relays, each represents 4.0% of region total
-      (p2pRelayRegionList "c" 8) # Currently 10 total region c relays, each represents 10.0% of region total
-      (p2pRelayRegionList "d" 12) # Currently 15 total region d relays, each represents 6.67% of region total
-      (p2pRelayRegionList "e" 12) # Currently 15 total region e relays, each represents 6.67% of region total
-      (p2pRelayRegionList "f" 8) # Currently 10 total region f relays, each represents 10.0% of region total
+      (p2pRelayRegionList "a" 36) # Currently 40 total region a relays, each represents 2.5% of region total
+      (p2pRelayRegionList "b" 23) # Currently 25 total region b relays, each represents 4.0% of region total
+      (p2pRelayRegionList "c" 9) # Currently 10 total region c relays, each represents 10.0% of region total
+      (p2pRelayRegionList "d" 14) # Currently 15 total region d relays, each represents 6.67% of region total
+      (p2pRelayRegionList "e" 14) # Currently 15 total region e relays, each represents 6.67% of region total
+      (p2pRelayRegionList "f" 9) # Currently 10 total region f relays, each represents 10.0% of region total
     ]))
   ]) (
     map (withModule {

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -180,12 +180,12 @@ let
       };
     } (lib.flatten [
       # See the nixops deploy [--build-only] [--include ...] trace for calculated p2p percentages per region.
-      (p2pRelayRegionList "a" 24) # Currently 40 total region a relays, each represents 2.5% of region total
-      (p2pRelayRegionList "b" 15) # Currently 25 total region b relays, each represents 4.0% of region total
-      (p2pRelayRegionList "c" 6) # Currently 10 total region c relays, each represents 10.0% of region total
-      (p2pRelayRegionList "d" 9) # Currently 15 total region d relays, each represents 6.67% of region total
-      (p2pRelayRegionList "e" 9) # Currently 15 total region e relays, each represents 6.67% of region total
-      (p2pRelayRegionList "f" 6) # Currently 10 total region f relays, each represents 10.0% of region total
+      (p2pRelayRegionList "a" 28) # Currently 40 total region a relays, each represents 2.5% of region total
+      (p2pRelayRegionList "b" 18) # Currently 25 total region b relays, each represents 4.0% of region total
+      (p2pRelayRegionList "c" 7) # Currently 10 total region c relays, each represents 10.0% of region total
+      (p2pRelayRegionList "d" 11) # Currently 15 total region d relays, each represents 6.67% of region total
+      (p2pRelayRegionList "e" 11) # Currently 15 total region e relays, each represents 6.67% of region total
+      (p2pRelayRegionList "f" 7) # Currently 10 total region f relays, each represents 10.0% of region total
     ]))
   ]) (
     map (withModule {

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -80,11 +80,19 @@ let
   ];
 
   stakingPoolNodes = fullyConnectNodes [
+    # The following legacy defns of the stake pools will fail on a socket assertion now that mainnet is set EnableP2P by default.
+    # However, since these machines have been migrated, we don't want to be able to deploy these machines, so the assertion prevents us from doing so.
+    # Ideally, we would simply remove these machines from the topology, but the stack was written with the assumption that block producers must be defined.
     (mkStakingPool "a" 1 "IOG1" { nodeId = 8; })
-
     (mkStakingPool "b" 1 "IOGP2" { nodeId = 28; })
     (mkStakingPool "c" 1 "IOGP3" { nodeId = 29; })
     (mkStakingPool "d" 1 "IOGP4" { nodeId = 30; })
+
+    # If we did need to re-deploy the pools, the following service modification is one way we could do so
+    # (mkStakingPool "a" 1 "IOG1" { nodeId = 8; services.cardano-node = {useNewTopology = lib.mkForce false; extraNodeConfig = {EnableP2P = lib.mkForce false;};};})
+    # (mkStakingPool "b" 1 "IOGP2" { nodeId = 28; services.cardano-node = {useNewTopology = lib.mkForce false; extraNodeConfig = {EnableP2P = lib.mkForce false;};};})
+    # (mkStakingPool "c" 1 "IOGP3" { nodeId = 29; services.cardano-node = {useNewTopology = lib.mkForce false; extraNodeConfig = {EnableP2P = lib.mkForce false;};};})
+    # (mkStakingPool "d" 1 "IOGP4" { nodeId = 30; services.cardano-node = {useNewTopology = lib.mkForce false; extraNodeConfig = {EnableP2P = lib.mkForce false;};};})
   ];
 
   coreNodes = bftCoreNodes ++ stakingPoolNodes;

--- a/topologies/mainnet.nix
+++ b/topologies/mainnet.nix
@@ -172,20 +172,20 @@ let
         # Make 3rd party producers localRoots rather than publicRoots for a 1:1 equivalency with legacy topology.
         useInstancePublicProducersAsProducers = true;
 
-        # Don't use any chain source outside of declared localRoots until after slot correlating with ~2023-07-14 21:44:58Z:
-        usePeersFromLedgerAfterSlot = 97804807;
+        # Don't use any chain source outside of declared localRoots until after slot correlating with ~2023-08-18 21:44:53Z:
+        usePeersFromLedgerAfterSlot = 100828802;
 
         # Ensure p2p relay node instances utilize the same number of producers as legacy relays as best as possible
         extraNodeConfig.TargetNumberOfActivePeers = maxProducersPerNode;
       };
     } (lib.flatten [
       # See the nixops deploy [--build-only] [--include ...] trace for calculated p2p percentages per region.
-      (p2pRelayRegionList "a" 28) # Currently 40 total region a relays, each represents 2.5% of region total
-      (p2pRelayRegionList "b" 18) # Currently 25 total region b relays, each represents 4.0% of region total
-      (p2pRelayRegionList "c" 7) # Currently 10 total region c relays, each represents 10.0% of region total
-      (p2pRelayRegionList "d" 11) # Currently 15 total region d relays, each represents 6.67% of region total
-      (p2pRelayRegionList "e" 11) # Currently 15 total region e relays, each represents 6.67% of region total
-      (p2pRelayRegionList "f" 7) # Currently 10 total region f relays, each represents 10.0% of region total
+      (p2pRelayRegionList "a" 32) # Currently 40 total region a relays, each represents 2.5% of region total
+      (p2pRelayRegionList "b" 20) # Currently 25 total region b relays, each represents 4.0% of region total
+      (p2pRelayRegionList "c" 8) # Currently 10 total region c relays, each represents 10.0% of region total
+      (p2pRelayRegionList "d" 12) # Currently 15 total region d relays, each represents 6.67% of region total
+      (p2pRelayRegionList "e" 12) # Currently 15 total region e relays, each represents 6.67% of region total
+      (p2pRelayRegionList "f" 8) # Currently 10 total region f relays, each represents 10.0% of region total
     ]))
   ]) (
     map (withModule {


### PR DESCRIPTION
* Increasing high load relays to ~100% p2p over time
* Bumps db-sync snapshots to 13.1.1.3
* Bumps node deploy on relays to `8.7.2` release, and iohk-nix to master for node `8.7.2` config
* Sets a mainnet legacy network topology relay canary and a reduced RAM relay canary
* Increases the monitoring scrape timeout to 60 seconds to avoid transient scrape errors
* Pins relays-new definition for mainnet to the proper legacy name: `relays-new.cardano-mainnet.iohk.io` to avoid conflict with the iohk-nix master `backbone.cardano-mainnet.iohk.io` which is appropriate for machines outside the cardano-ops cluster.
* Adjust the latency alert threshold
* Pin the snapshots dbsync machine to node `8.1.2` until the next dbsync release and adjust systemd timeouts
* Adjust the metadata server rate limit and nginx return byte logging
* Add a deployment note for the migrated legacy mainnet pools
